### PR TITLE
chore: add repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.11.3-beta.1"
 edition = "2021"
 description = "Automatically load secrets from your preferred vault as environment variables, and clear them once your shell command is over."
 license = "MPL-2.0"
+repository = "https://github.com/zifeo/lade"
 
 [dependencies]
 anyhow = "1.0.82"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.11.3-beta.1"
 edition = "2021"
 description = "Lade SDK"
 license = "MPL-2.0"
+repository = "https://github.com/zifeo/lade"
 
 [dependencies]
 access-json = "0.1.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.