### PR TITLE
feat: add support for per-user secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ nix = { version = "0.30.1", features = ["signal"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
+tempfile = "3.10.1"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ command regex:
   ...
 ```
 
+### Per User Secrets
+
+In the case where you have different secrets for different users, you can
+specify a different secret for each user by specifying each user as a key under
+a variable.
+```yaml
+command regex:
+  SAME_SECRET_FOR_EVERYONE: hello_world
+  SECRET_FOR_THE_USER: 
+    alex: alex_secret
+    zifeo: zifeo_secret
+```
+Lade will use the current user by default. you can change this by setting the
+`user` subcommand.
+```sh
+lade user  # get currently set user
+lade user tonystark  # set user to tonystark
+lade user --reset  # reset user, fallback to current user
+```
+
+
 ## Loaders
 
 Most of the vault loaders use their native CLI to operate. This means you must

--- a/lade.yml
+++ b/lade.yml
@@ -64,4 +64,3 @@
   SECRET_FOR_THE_USER: 
     alex: alex
     zifeo: zifeo
-    sura: sura

--- a/lade.yml
+++ b/lade.yml
@@ -58,3 +58,9 @@
 
 ^echo "test:
   TEST: "test-value"
+
+^echo user:
+  SAME_SECRET_FOR_EVERYONE: everyone
+  SECRET_FOR_THE_USER: 
+    alex: alex
+    zifeo: zifeo

--- a/lade.yml
+++ b/lade.yml
@@ -64,3 +64,4 @@
   SECRET_FOR_THE_USER: 
     alex: alex
     zifeo: zifeo
+    sura: sura

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,11 +46,6 @@ pub enum Command {
         #[arg(long)]
         reset: bool,
     },
-    //GetUser,
-    ///// Set lade user
-    //SetUser {
-    //    user: String,
-    //},
 }
 
 #[derive(Parser, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,11 +38,19 @@ pub enum Command {
     Set(EvalCommand),
     /// Unset environment for shell.
     Unset(EvalCommand),
-    GetUser,
-    /// Set lade user
-    SetUser {
-        user: String,
+    /// Manage user
+    User {
+        /// The username to set
+        username: Option<String>,
+        /// Reset/remove the current user. lade will fallback to the OS user for secrets
+        #[arg(long)]
+        reset: bool,
     },
+    //GetUser,
+    ///// Set lade user
+    //SetUser {
+    //    user: String,
+    //},
 }
 
 #[derive(Parser, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,6 +38,11 @@ pub enum Command {
     Set(EvalCommand),
     /// Unset environment for shell.
     Unset(EvalCommand),
+    GetUser,
+    /// Set lade user
+    SetUser {
+        user: String,
+    },
 }
 
 #[derive(Parser, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,9 +113,11 @@ impl Config {
                         if let Some(user) = &user {
                             if let Some(user_secret) = user_secrets.get(user) {
                                 acc.insert(key.to_string(), user_secret.to_string());
+                            } else {
+                                eprintln!("Warning: No secret found for exsiting user '{}' key '{}'. Use 'lade set-user <USER>' to set a user.", user, key);
                             }
                         } else {
-                            todo!("recommend users to run lade set user first")
+                            eprintln!("Warning: Secret '{}' requires a user to be set. Please set one using 'lade set-user <USER>'.", key);
                         }
                     }
                     None => {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,12 +99,7 @@ impl Config {
         path: PathBuf,
         rule: LadeRule,
     ) -> Result<(Output, HashMap<String, String>)> {
-        let project = directories::ProjectDirs::from("com", "zifeo", "lade")
-            .expect("cannot get directory for projet");
-
-        let config_path = project.config_local_dir().join("config.json");
-
-        let local_config = GlobalConfig::load(config_path.clone()).await?;
+        let local_config = GlobalConfig::load().await?;
         let user = local_config.user;
 
         let secrets_with_single_user = rule.secrets.keys().fold(

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,11 +14,17 @@ use std::fs::File;
 pub type Output = Option<PathBuf>;
 
 #[derive(Deserialize, Debug, Clone)]
+pub enum LadeSecret {
+    Secret(String),
+    User(HashMap<String, String>),
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct LadeRule {
     #[serde(rename = ".")]
     pub output: Output,
     #[serde(flatten)]
-    pub secrets: HashMap<String, String>,
+    pub secrets: HashMap<String, LadeSecret>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -125,3 +131,12 @@ impl Config {
             .collect()
     }
 }
+
+
+#[test]
+fn test_lade_secrets_yaml() {
+
+}
+
+
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,11 +132,11 @@ impl Config {
                                 if let Some(user_secret) = user_secrets.get(&user) {
                                     acc.insert(key.to_string(), user_secret.to_string());
                                 } else {
-                                    eprintln!("Error: No secret found for user '{}' and key '{}'. Set a user with 'lade set-user <USER>'.", user, key);
+                                    eprintln!("Error: No secret found for user '{}' and key '{}'. Set a user with 'lade user <USER>'.", user, key);
                                 }
                             }
                             None => {
-                                eprintln!("Error: Secret '{}' requires a user. Set one with 'lade set-user <USER>'.", key);
+                                eprintln!("Error: Secret '{}' requires a user. Set one with 'lade user <USER>'.", key);
                             }
                         }
                     }

--- a/src/global_config.rs
+++ b/src/global_config.rs
@@ -9,6 +9,7 @@ use tokio::fs;
 #[derive(Deserialize, Serialize)]
 pub struct GlobalConfig {
     pub update_check: DateTime<Utc>,
+    pub user: Option<String>,
 }
 
 impl GlobalConfig {
@@ -20,6 +21,7 @@ impl GlobalConfig {
         } else {
             let config = GlobalConfig {
                 update_check: Utc::now(),
+                user: None,
             };
             config.save(path).await?;
             Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,28 +296,40 @@ async fn main() -> Result<()> {
             println!("Auto launcher uninstalled in {}", shell.uninstall()?);
             Ok(())
         }
-        Command::SetUser { user } => {
+        Command::User { username, reset } => {
             let mut local_config = GlobalConfig::load().await?;
 
-            if user.is_empty() {
-                println!("no user provided");
+            //reset user
+            if reset {
+                local_config.user = None;
+                local_config.save().await?;
+
+                println!("Successfully reset lade user");
                 return Ok(());
             }
 
-            local_config.user = Some(user.clone());
-            let _ = local_config.save().await?;
+            // set user
+            if let Some(user) = username {
+                if user.is_empty() {
+                    println!("No user provided");
+                    return Ok(());
+                }
 
-            println!("Successfully set user to {}", user);
-            Ok(())
-        }
-        Command::GetUser => {
-            let local_config = GlobalConfig::load().await?;
-            println!(
-                "{}",
-                local_config
-                    .user
-                    .unwrap_or("no user set. please use lade set-user to set a user".to_string())
-            );
+                local_config.user = Some(user.clone());
+                let _ = local_config.save().await?;
+
+                println!("Successfully set user to {}", user);
+                return Ok(());
+            }
+
+            // get user
+
+            if let Some(user) = local_config.user {
+                println!("{}", user);
+            } else {
+                println!("No user set. Lade will use the current OS user.");
+            }
+
             Ok(())
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,6 @@ use global_config::GlobalConfig;
 use config::{Config, LadeFile, Output};
 
 async fn upgrade_check() -> Result<()> {
-    let project = directories::ProjectDirs::from("com", "zifeo", "lade")
-        .expect("cannot get directory for projet");
-
-    let config_path = project.config_local_dir().join("config.json");
-    debug!("config_path: {:?}", config_path);
     let mut local_config = GlobalConfig::load().await?;
 
     if local_config.update_check + TimeDelta::try_days(1).unwrap() < Utc::now() {
@@ -275,7 +270,6 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Unset(EvalCommand { commands }) => {
-            eprintln!("unsetting: {:?}", commands);
             let command = commands.join(" ");
 
             let mut keys = config.collect_keys(&command);

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn upgrade_check() -> Result<()> {
 
     let config_path = project.config_local_dir().join("config.json");
     debug!("config_path: {:?}", config_path);
-    let mut local_config = GlobalConfig::load(config_path.clone()).await?;
+    let mut local_config = GlobalConfig::load().await?;
 
     if local_config.update_check + TimeDelta::try_days(1).unwrap() < Utc::now() {
         debug!("checking for update");
@@ -53,7 +53,7 @@ async fn upgrade_check() -> Result<()> {
         }
 
         local_config.update_check = Utc::now();
-        local_config.save(config_path).await?;
+        local_config.save().await?;
     }
     Ok(())
 }
@@ -303,10 +303,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::SetUser { user } => {
-            let project = directories::ProjectDirs::from("com", "zifeo", "lade")
-                .expect("cannot get directory for projet");
-            let config_path = project.config_local_dir().join("config.json");
-            let mut local_config = GlobalConfig::load(config_path.clone()).await?;
+            let mut local_config = GlobalConfig::load().await?;
 
             if user.is_empty() {
                 println!("no user provided");
@@ -314,15 +311,12 @@ async fn main() -> Result<()> {
             }
 
             local_config.user = Some(user);
-            let _ = local_config.save(config_path).await?;
+            let _ = local_config.save().await?;
 
             Ok(())
         }
         Command::GetUser => {
-            let project = directories::ProjectDirs::from("com", "zifeo", "lade")
-                .expect("cannot get directory for projet");
-            let config_path = project.config_local_dir().join("config.json");
-            let local_config = GlobalConfig::load(config_path.clone()).await?;
+            let local_config = GlobalConfig::load().await?;
             println!(
                 "{}",
                 local_config

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Command::Unset(EvalCommand { commands }) => {
-            debug!("unsetting: {:?}", commands);
+            eprintln!("unsetting: {:?}", commands);
             let command = commands.join(" ");
 
             let mut keys = config.collect_keys(&command);
@@ -310,9 +310,10 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
 
-            local_config.user = Some(user);
+            local_config.user = Some(user.clone());
             let _ = local_config.save().await?;
 
+            println!("Successfully set user to {}", user);
             Ok(())
         }
         Command::GetUser => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,35 @@ async fn main() -> Result<()> {
             println!("Auto launcher uninstalled in {}", shell.uninstall()?);
             Ok(())
         }
+        Command::SetUser { user } => {
+            let project = directories::ProjectDirs::from("com", "zifeo", "lade")
+                .expect("cannot get directory for projet");
+            let config_path = project.config_local_dir().join("config.json");
+            let mut local_config = GlobalConfig::load(config_path.clone()).await?;
+
+            if user.is_empty() {
+                println!("no user provided");
+                return Ok(());
+            }
+
+            local_config.user = Some(user);
+            let _ = local_config.save(config_path).await?;
+
+            Ok(())
+        }
+        Command::GetUser => {
+            let project = directories::ProjectDirs::from("com", "zifeo", "lade")
+                .expect("cannot get directory for projet");
+            let config_path = project.config_local_dir().join("config.json");
+            let local_config = GlobalConfig::load(config_path.clone()).await?;
+            println!(
+                "{}",
+                local_config
+                    .user
+                    .unwrap_or("no user set. please use lade set-user to set a user".to_string())
+            );
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
# Add support for per-user secrets

Closes #104

## Changes

- Introduce `LadeSecret` enum to handle both global secrets (`Secret(String)`) and user-specific secrets (`User(HashMap<String, String>)`).
- Update `LadeRule` to use `HashMap<String, LadeSecret>` for secrets.
- Modify `hydrate_rule` to load the global user config and select the appropriate secret based on the set user. If no user is set, a warning is placed to recommend running `lade set-user`.
- Add `user: Option<String>` field to `GlobalConfig`.
- Refactor `GlobalConfig::load()` and `save()` to handle path locally.
- Add CLI commands: `lade get-user` to display the current user (or prompt to set one) and `lade set-user <user>` to set the user.
- Update `upgrade_check` to use the new `load()` without explicit path.
- Add dev-dependency `tempfile` for testing.
- Add test `test_lade_secrets_on_yaml` to verify YAML parsing of mixed secret types.
- Update example `lade.yml` to demonstrate user-specific secrets syntax.

## Example Usage

After setting a user with `lade set-user alex`, the following in `lade.yml` will resolve `TF_HTTP_USERNAME` to the value for "alex":

```
^tofu:
  SAME_SECRET_FOR_EVERYONE: infisical://app.infisical.com/63a2290a0edf8bf1f65e3784/dev/INFISICAL_A
  TF_HTTP_USERNAME:
    zifeo: infisical://app.infisical.com/63a2290a0edf8bf1f65e3784/dev/INFISICAL_B
    alex: infisical://app.infisical.com/63a2290a0edf8bf1f65e3784/dev/INFISICAL_C
  TF_HTTP_PASSWORD: ...
```