### PR TITLE
feat: add lade bench for parse, match, and hydrate timing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,11 +52,15 @@ jobs:
           brew update
           brew install fish zsh
 
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v4
+
       - name: Tool versions
         run: |
           bash --version
           fish --version
           zsh --version
+          op --version
 
       - name: Run native tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Release notes are also published on [GitHub Releases](https://github.com/zifeo/l
   The same pattern can be a list of bodies with different `when`.
 - **`.silence` hydration progress**: `silence: true` under `.` skips that
   rule's secret progress lines at hydrate time. Hydration itself is unchanged.
+- **`lade bench`**: times the incompressible path (parse all `lade.yml` files
+  and regex match) and the variable path (secret hydrate per loaded rule).
+  Human mode prints parse/match first, then each rule as it finishes, then
+  wall-clock `total`. Hydrates run concurrently. `--timeout` caps each rule
+  (`5s` by default). Errors sit on the next indented line. `--json` includes
+  `total_ms` and `timeout_ms`. Secret values are not printed. Network acquire
+  is not run.
 
 ### Changed
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,7 @@ use clap_verbosity_flag::Verbosity;
 
 use clap::Parser;
 use std::ffi::OsString;
+use std::time::Duration;
 
 #[derive(Parser, Debug)]
 pub struct UpgradeCommand {
@@ -57,12 +58,51 @@ pub struct StatusCommand {
     pub json: bool,
 }
 
+#[derive(Parser, Debug)]
+pub struct BenchCommand {
+    /// Emit a machine-readable JSON report to stdout instead of human text.
+    #[clap(long, default_value_t = false)]
+    pub json: bool,
+    /// Per-rule hydrate cap, for example `5s` or `500ms`.
+    #[clap(long, default_value = "5s", value_parser = parse_timeout)]
+    pub timeout: Duration,
+}
+
+pub fn parse_timeout(raw: &str) -> Result<Duration, String> {
+    let raw = raw.trim();
+    let (number, unit) = if let Some(number) = raw.strip_suffix("ms") {
+        (number, "ms")
+    } else if let Some(number) = raw.strip_suffix('s') {
+        (number, "s")
+    } else if let Some(number) = raw.strip_suffix('m') {
+        (number, "m")
+    } else {
+        return Err("use a duration like 5s, 500ms, or 2m".to_string());
+    };
+    let amount: u64 = number
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid duration '{raw}'"))?;
+    let timeout = match unit {
+        "ms" => Duration::from_millis(amount),
+        "s" => Duration::from_secs(amount),
+        "m" => Duration::from_secs(amount.saturating_mul(60)),
+        _ => unreachable!("unit is one of ms, s, m"),
+    };
+    if timeout.is_zero() {
+        return Err("timeout must be greater than 0".to_string());
+    }
+    Ok(timeout)
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Upgrade lade.
     Upgrade(UpgradeCommand),
     /// Report lade version, config, hooks, and CLI compatibility.
     Status(StatusCommand),
+    /// Time config parse, match, and per-rule secret resolution.
+    Bench(BenchCommand),
     /// Enable preexec shell hooks.
     On,
     /// Disable preexec shell hooks.
@@ -119,4 +159,36 @@ pub struct Args {
 
     #[command(flatten)]
     pub verbose: Verbosity,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_timeout_defaults_to_five_seconds() {
+        let args = Args::try_parse_from(["lade", "bench"]).unwrap();
+        match args.command {
+            Some(Command::Bench(bench)) => {
+                assert!(!bench.json);
+                assert_eq!(bench.timeout, Duration::from_secs(5));
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn bench_timeout_parses_ms() {
+        let args = Args::try_parse_from(["lade", "bench", "--timeout", "500ms"]).unwrap();
+        match args.command {
+            Some(Command::Bench(bench)) => assert_eq!(bench.timeout, Duration::from_millis(500)),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_timeout_rejects_zero_and_bare_number() {
+        assert!(parse_timeout("0s").is_err());
+        assert!(parse_timeout("5").is_err());
+    }
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,362 @@
+use std::collections::BTreeSet;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use futures::stream::{FuturesUnordered, StreamExt};
+use serde::Serialize;
+use tokio::time::timeout;
+
+use crate::args::BenchCommand;
+use crate::config::{Config, LadeFile, LadeRule, RuleWhen, saved_user};
+use crate::message_box;
+
+/// A command that is only used to exercise `RegexSet` matching. A catch-all
+/// `.` still matches it. That is fine: the incompressible cost is the scan.
+const MATCH_PROBE: &str = "lade-bench-no-match";
+const ERROR_MAX_CHARS: usize = 100;
+
+#[derive(Serialize)]
+struct Incompressible {
+    parse_ms: f64,
+    match_ms: f64,
+    files: usize,
+    rules: usize,
+}
+
+#[derive(Serialize)]
+struct RuleReport {
+    file: PathBuf,
+    pattern: String,
+    when: &'static str,
+    hydrate_ms: f64,
+    providers: Vec<String>,
+    error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct BenchReport {
+    incompressible: Incompressible,
+    rules: Vec<RuleReport>,
+    total_ms: f64,
+    timeout_ms: f64,
+}
+
+pub async fn run(opts: BenchCommand) -> Result<()> {
+    let started = Instant::now();
+    let cwd = std::env::current_dir()?;
+    let parse_started = Instant::now();
+    let config = match LadeFile::build(cwd) {
+        Ok(config) => config,
+        Err(e) => {
+            message_box::MessageBox::new()
+                .error()
+                .line("Lade could not parse a config file:")
+                .line("")
+                .paragraph(e.to_string())
+                .line("")
+                .line("Hint: check the file format.")
+                .print_stderr();
+            std::process::exit(crate::exit_codes::FAILURE);
+        }
+    };
+    let parse_ms = elapsed_ms(parse_started);
+
+    let match_started = Instant::now();
+    let _ = config.collect(MATCH_PROBE);
+    let match_ms = elapsed_ms(match_started);
+
+    let files = config
+        .rule_entries()
+        .map(|(path, _, _)| path.clone())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let entries: Vec<(PathBuf, String, LadeRule)> = config
+        .rule_entries()
+        .map(|(path, pattern, rule)| (path.clone(), pattern.to_string(), rule.clone()))
+        .collect();
+    let incompressible = Incompressible {
+        parse_ms,
+        match_ms,
+        files,
+        rules: entries.len(),
+    };
+
+    if !opts.json {
+        print_incompressible(&incompressible);
+        println!("variable");
+        if entries.is_empty() {
+            println!("  (no rules)");
+            println!("total: {}", format_ms(elapsed_ms(started)));
+            return Ok(());
+        }
+        io::stdout().flush()?;
+    }
+
+    let config = Arc::new(config);
+    let saved = Arc::new(saved_user().await?);
+    let mut running = FuturesUnordered::new();
+    for (path, pattern, rule) in entries {
+        let config = Arc::clone(&config);
+        let saved = Arc::clone(&saved);
+        let hydrate_timeout = opts.timeout;
+        running.push(async move {
+            time_rule(&config, &path, &pattern, &rule, &saved, hydrate_timeout).await
+        });
+    }
+
+    let mut rules = Vec::new();
+    while let Some(report) = running.next().await {
+        if !opts.json {
+            println!("{}", format_rule_line(&report));
+            io::stdout().flush()?;
+        }
+        rules.push(report);
+    }
+
+    if opts.json {
+        rules.sort_by(|a, b| {
+            a.hydrate_ms
+                .total_cmp(&b.hydrate_ms)
+                .then_with(|| a.pattern.cmp(&b.pattern))
+                .then_with(|| a.file.cmp(&b.file))
+        });
+        let report = BenchReport {
+            incompressible,
+            rules,
+            total_ms: elapsed_ms(started),
+            timeout_ms: duration_ms(opts.timeout),
+        };
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("total: {}", format_ms(elapsed_ms(started)));
+    }
+    Ok(())
+}
+
+async fn time_rule(
+    config: &Config,
+    path: &Path,
+    pattern: &str,
+    rule: &LadeRule,
+    saved_user: &Option<String>,
+    hydrate_timeout: Duration,
+) -> RuleReport {
+    let providers = provider_kinds(path, rule, saved_user);
+    let started = Instant::now();
+    let error = match timeout(
+        hydrate_timeout,
+        config.hydrate_rules(&[(path.to_path_buf(), rule.clone())], saved_user),
+    )
+    .await
+    {
+        Ok(Ok(_)) => None,
+        Ok(Err(e)) => Some(short_error(&e.to_string())),
+        Err(_) => Some(format!("timeout {}", format_timeout(hydrate_timeout))),
+    };
+    RuleReport {
+        file: rule_file(path),
+        pattern: pattern.to_string(),
+        when: when_label(rule),
+        hydrate_ms: elapsed_ms(started),
+        providers,
+        error,
+    }
+}
+
+fn provider_kinds(path: &Path, rule: &LadeRule, saved_user: &Option<String>) -> Vec<String> {
+    let pair = vec![(path.to_path_buf(), rule.clone())];
+    let mut kinds = BTreeSet::new();
+    if let Ok(plan) = Config::secret_sources_from_rules(&pair, saved_user) {
+        for source in plan.sources.values() {
+            kinds.insert(provider_kind(source));
+        }
+    }
+    for binding in Config::network_bindings_from_rules(&pair, saved_user) {
+        kinds.insert(provider_kind(&binding.uri));
+    }
+    kinds.into_iter().collect()
+}
+
+fn provider_kind(source: &str) -> String {
+    match source.split_once("://").map(|(scheme, _)| scheme) {
+        Some("op") => "1password".to_string(),
+        Some("sh" | "bash" | "zsh" | "fish") => "sh".to_string(),
+        Some(scheme) => scheme.to_string(),
+        None => "raw".to_string(),
+    }
+}
+
+fn rule_file(dir: &Path) -> PathBuf {
+    let yaml = dir.join("lade.yaml");
+    if yaml.exists() {
+        yaml
+    } else {
+        dir.join("lade.yml")
+    }
+}
+
+fn when_label(rule: &LadeRule) -> &'static str {
+    match rule
+        .config
+        .as_ref()
+        .map(|config| config.when)
+        .unwrap_or_default()
+    {
+        RuleWhen::Always => "always",
+        RuleWhen::Human => "human",
+        RuleWhen::Agent => "agent",
+    }
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    duration_ms(started.elapsed())
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    (duration.as_secs_f64() * 1_000.0 * 1_000.0).round() / 1_000.0
+}
+
+fn format_timeout(timeout: Duration) -> String {
+    if timeout.as_millis().is_multiple_of(1000) {
+        format!("{}s", timeout.as_secs())
+    } else {
+        format!("{}ms", timeout.as_millis())
+    }
+}
+
+fn print_incompressible(inc: &Incompressible) {
+    println!("incompressible");
+    println!(
+        "  parse: {} ({} files, {} rules)",
+        format_ms(inc.parse_ms),
+        inc.files,
+        inc.rules
+    );
+    println!("  match: {}", format_ms(inc.match_ms));
+}
+
+fn format_rule_line(rule: &RuleReport) -> String {
+    let providers = if rule.providers.is_empty() {
+        "-".to_string()
+    } else {
+        rule.providers.join(",")
+    };
+    let line = format!(
+        "  {}  {}  {}  {}  {providers}",
+        display_path(&rule.file),
+        rule.pattern,
+        rule.when,
+        format_ms(rule.hydrate_ms),
+    );
+    match &rule.error {
+        Some(err) => format!("{line}\n    error  {err}"),
+        None => line,
+    }
+}
+
+fn short_error(err: &str) -> String {
+    let lines: Vec<&str> = err
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let picked = lines
+        .iter()
+        .copied()
+        .find(|line| {
+            let lower = line.to_ascii_lowercase();
+            lower.starts_with("message:")
+                || lower.contains("connection refused")
+                || lower.contains("not found")
+                || lower.contains("cannot parse")
+                || lower.contains("timed out")
+                || lower.contains("timeout")
+        })
+        .or_else(|| lines.first().copied())
+        .unwrap_or(err);
+    let picked = picked
+        .strip_prefix("Message:")
+        .map(str::trim)
+        .unwrap_or(picked);
+    truncate_chars(picked, ERROR_MAX_CHARS)
+}
+
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let keep = max.saturating_sub(3);
+    let mut out: String = text.chars().take(keep).collect();
+    out.push_str("...");
+    out
+}
+
+fn format_ms(ms: f64) -> String {
+    format!("{ms:.3} ms")
+}
+
+fn display_path(path: &Path) -> String {
+    if let Some(home) = directories::UserDirs::new().map(|u| u.home_dir().to_path_buf())
+        && let Ok(stripped) = path.strip_prefix(&home)
+    {
+        if stripped.as_os_str().is_empty() {
+            return "~".to_string();
+        }
+        return format!("~/{}", stripped.display());
+    }
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RuleReport, elapsed_ms, format_rule_line, short_error, truncate_chars};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn elapsed_ms_rounds_to_micros() {
+        let started = Instant::now() - Duration::from_micros(1234);
+        let ms = elapsed_ms(started);
+        assert!(ms >= 1.234);
+        assert!(ms < 50.0);
+    }
+
+    #[test]
+    fn short_error_prefers_message_line() {
+        let err = "Infisical error: EOF\nMessage: Project with ID 'abc' not found\nRequest: GET x";
+        assert_eq!(short_error(err), "Project with ID 'abc' not found");
+    }
+
+    #[test]
+    fn short_error_prefers_connection_refused() {
+        let err = "Vault error: EOF\nGet \"https://127.0.0.1:8200\": connection refused";
+        assert!(short_error(err).contains("connection refused"));
+        assert!(!short_error(err).contains('\n'));
+    }
+
+    #[test]
+    fn truncate_chars_adds_ellipsis() {
+        assert_eq!(truncate_chars("abcd", 4), "abcd");
+        assert_eq!(truncate_chars("abcdefghij", 7), "abcd...");
+    }
+
+    #[test]
+    fn error_sits_on_the_next_line() {
+        let line = format_rule_line(&RuleReport {
+            file: PathBuf::from("/tmp/lade.yml"),
+            pattern: "^echo g".into(),
+            when: "always",
+            hydrate_ms: 115.335,
+            providers: vec!["passbolt".into()],
+            error: Some("logging in: connection refused".into()),
+        });
+        let lines: Vec<&str> = line.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("passbolt"));
+        assert!(!lines[0].contains("error"));
+        assert_eq!(lines[1], "    error  logging in: connection refused");
+    }
+}

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -95,7 +95,7 @@ impl LadeFile {
         }
 
         let regex_set = RegexSet::new(&regex_strs)?;
-        Ok(Config::new(rules, regex_set))
+        Ok(Config::new(rules, regex_strs, regex_set))
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -233,12 +233,29 @@ pub(crate) async fn saved_user() -> Result<Option<String>> {
 
 pub struct Config {
     rules: Vec<(PathBuf, LadeRule)>,
+    patterns: Vec<String>,
     regex_set: RegexSet,
 }
 
 impl Config {
-    pub(crate) fn new(rules: Vec<(PathBuf, LadeRule)>, regex_set: RegexSet) -> Self {
-        Config { rules, regex_set }
+    pub(crate) fn new(
+        rules: Vec<(PathBuf, LadeRule)>,
+        patterns: Vec<String>,
+        regex_set: RegexSet,
+    ) -> Self {
+        Config {
+            rules,
+            patterns,
+            regex_set,
+        }
+    }
+
+    /// Loaded rules in overlay order, with the file directory and pattern.
+    pub(crate) fn rule_entries(&self) -> impl Iterator<Item = (&PathBuf, &str, &LadeRule)> {
+        self.rules
+            .iter()
+            .zip(self.patterns.iter())
+            .map(|((path, rule), pattern)| (path, pattern.as_str(), rule))
     }
 
     /// Rules matching `command`, in overlay order: parent `lade.yml` then

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::{env, io::Read, time::Duration};
 mod access;
 mod args;
 mod audience;
+mod bench;
 mod compat;
 mod config;
 mod context;
@@ -136,6 +137,7 @@ async fn run() -> Result<()> {
         }
         Command::Upgrade(opts) => return upgrade::perform(opts).await,
         Command::Status(opts) => return status::run(opts).await,
+        Command::Bench(opts) => return bench::run(opts).await,
         Command::User { username, reset } => {
             if reset {
                 GlobalConfig::update(|c| c.user = None).await?;

--- a/tests/bench.rs
+++ b/tests/bench.rs
@@ -1,0 +1,151 @@
+mod common;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_bench_json_splits_incompressible_and_variable() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"^echo raw\":\n  A: one\n\"^echo sh\":\n  B: sh://printf x\n",
+    )
+    .unwrap();
+    let output = common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["bench", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value =
+        serde_json::from_slice(&output).expect("bench --json must emit valid JSON");
+    assert!(value.get("incompressible").is_some());
+    assert!(value["incompressible"]["parse_ms"].as_f64().is_some());
+    assert!(value["incompressible"]["match_ms"].as_f64().is_some());
+    assert_eq!(value["incompressible"]["files"], 1);
+    assert_eq!(value["incompressible"]["rules"], 2);
+    assert!(value["total_ms"].as_f64().is_some());
+    let rules = value["rules"].as_array().expect("rules array");
+    assert_eq!(rules.len(), 2);
+    let raw = rules
+        .iter()
+        .find(|rule| rule["pattern"] == "^echo raw")
+        .expect("raw rule");
+    assert_eq!(raw["when"], "always");
+    assert_eq!(raw["providers"][0], "raw");
+    assert!(raw["error"].is_null());
+    assert!(raw["hydrate_ms"].as_f64().is_some());
+    let sh = rules
+        .iter()
+        .find(|rule| rule["pattern"] == "^echo sh")
+        .expect("sh rule");
+    assert_eq!(sh["providers"][0], "sh");
+    assert!(sh["error"].is_null());
+    let stdout = String::from_utf8_lossy(&output);
+    assert!(
+        !stdout.contains("one"),
+        "bench must not print secret values: {stdout}"
+    );
+}
+
+#[test]
+fn test_bench_human_has_both_cost_sections() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(dir.path().join("lade.yml"), "\"^echo raw\":\n  A: one\n").unwrap();
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .arg("bench")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("incompressible"))
+        .stdout(predicates::str::contains("parse:"))
+        .stdout(predicates::str::contains("match:"))
+        .stdout(predicates::str::contains("variable"))
+        .stdout(predicates::str::contains("^echo raw"))
+        .stdout(predicates::str::contains("raw"))
+        .stdout(predicates::str::contains("total:"));
+}
+
+#[test]
+fn test_bench_reports_hydrate_error_per_rule() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"^echo bad\":\n  A: op://bad\n",
+    )
+    .unwrap();
+    let output = common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["bench", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value =
+        serde_json::from_slice(&output).expect("bench --json must emit valid JSON");
+    let err = value["rules"][0]["error"].as_str().expect("hydrate error");
+    assert!(err.contains("cannot parse") || err.contains("1Password"));
+    assert!(!err.contains('\n'));
+    assert!(value["rules"][0]["hydrate_ms"].as_f64().is_some());
+}
+
+#[test]
+fn test_bench_human_puts_error_on_next_line() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"^echo bad\":\n  A: op://bad\n",
+    )
+    .unwrap();
+    let stdout = String::from_utf8_lossy(
+        &common::lade(home.path())
+            .current_dir(dir.path())
+            .arg("bench")
+            .assert()
+            .success()
+            .get_output()
+            .stdout,
+    )
+    .into_owned();
+    let error_line = stdout
+        .lines()
+        .find(|line| line.starts_with("    error  "))
+        .expect("indented error line");
+    assert!(!error_line.contains("^echo bad"));
+}
+
+#[test]
+fn test_bench_hydrate_timeout_flag() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"^echo slow\":\n  A: sh://sleep 8\n",
+    )
+    .unwrap();
+    let started = std::time::Instant::now();
+    let output = common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["bench", "--json", "--timeout", "1s"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "1s cap should finish before 3s, took {elapsed:?}"
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output).expect("bench --json must emit valid JSON");
+    assert_eq!(value["timeout_ms"].as_f64(), Some(1000.0));
+    assert_eq!(value["rules"][0]["error"], "timeout 1s");
+    assert!(value["rules"][0]["hydrate_ms"].as_f64().unwrap() >= 1000.0);
+}


### PR DESCRIPTION
## Summary
- Add `lade bench` to time config parse/match and per-rule secret hydrate.
- Hydrates run concurrently with a per-rule `--timeout` (default 5s). `--json` reports timings. Secret values and network acquire are not included.

## Test plan
- [ ] `cargo test --workspace --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `lade bench` and `lade bench --json --timeout 500ms` in a repo with `lade.yml`
