### PR TITLE
feat: add Codex, Pi, and OpenCode preTool hosts

### DIFF
--- a/.agents/skills/lade/SKILL.md
+++ b/.agents/skills/lade/SKILL.md
@@ -43,7 +43,43 @@ For Claude Code, ensure `.claude/settings.json` contains:
 }
 ```
 
-With preTool hooks, run the user's command normally. Lade decides whether it matches `lade.yml`, rewrites matches to `lade inject`, and masks provider-resolved secrets from stdout/stderr. This avoids making the agent infer command regexes itself. `lade hook` is for Cursor and Claude Code.
+For Codex, open `/hooks` and trust the Lade command. An untrusted or
+`[features].hooks = false` hook is a silent no-op. Then ensure
+`.codex/hooks.json` contains:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}
+```
+
+For Pi, ensure `.pi/settings.json` contains:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}
+```
+
+Pi matches on `tool_name`, often lowercase `bash`.
+
+For OpenCode, ensure `.opencode/plugins/lade-pretool.js` is present. Native OpenCode loads that file and does not run Claude-style `hooks.json`. The plugin must export a function that returns a `tool.execute.before` hook.
+
+With preTool hooks, run the user's command normally. Lade decides whether it matches `lade.yml`, rewrites matches to `lade inject`, and masks provider-resolved secrets from stdout/stderr. This avoids making the agent infer command regexes itself. `lade hook` is for Cursor, Claude Code, Codex, Pi, and OpenCode.
 
 ## Fallback
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}

--- a/.opencode/plugins/lade-pretool.js
+++ b/.opencode/plugins/lade-pretool.js
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+
+const lade = process.env.LADE_BIN ?? "lade";
+
+// OpenCode loads every exported function in this file and calls it for hooks.
+export const LadePretool = async () => ({
+  "tool.execute.before": async (input, output) => {
+    const command = output.args?.command;
+    if (input.tool !== "bash" || typeof command !== "string") {
+      return;
+    }
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command },
+      hook_source: "opencode-plugin",
+    });
+    const result = spawnSync(lade, ["hook"], {
+      input: payload,
+      encoding: "utf8",
+      env: { ...process.env, OPENCODE: "1" },
+    });
+    if (result.status !== 0 || !result.stdout?.trim()) {
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      return;
+    }
+    const updated = parsed?.hookSpecificOutput?.updatedInput?.command;
+    if (typeof updated === "string") {
+      output.args.command = updated;
+    }
+  },
+});

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,17 @@ bash tests/installer_test.sh
 - Keep documented exit codes (`src/exit_codes.rs`) stable across minor
   versions. `lade status --json` keeps `version`, `global_config`, `hooks`,
   `project_config`, and `ok`; the `hooks` object is `preexec` plus `pretool`.
+- **`lade status` latest**: a successful daily GitHub check must persist
+  the tag (`latest_version` in the global config) so status can show it after
+  shell use. If the fetch failed, print when we last tried (`tried today at
+  14:25`, `tried yesterday at 09:05`). Do not print `not checked recently`
+  when a check was attempted. `version` in `--json` includes `latest`,
+  `last_check`, `update_available`, and `check_error`.
 
 ## Project layout
 
 - `src/` — CLI crate. Key modules: `pretool/` (`lade hook` preToolUse handler
-  plus install into Cursor/Claude configs), `audience.rs` (`detect()` for Via,
+  plus install into Cursor/Claude/Codex/Pi/OpenCode configs), `audience.rs` (`detect()` for Via,
   Audience, UI), `prompt.rs` (disclaimer flow), `inject.rs`/`exec/` (PTY
   execution + masking), `status.rs`, `shell/` (preexec integration), `config/`,
   `message_box/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ Release notes are also published on [GitHub Releases](https://github.com/zifeo/l
 ### Added
 
 - **`.when` audience detection**: `detect()` classifies every invocation as
-  preexec, pretool, or unset (`LADE_VIA`), then human vs agent. MCP and a bare
-  `lade inject` use the same function, including env signals when Via is empty.
-  The same pattern can be a list of bodies with different `when`.
+  preexec, pretool, or unset. `--pretool` (global) wins over `LADE_VIA`, then
+  the subcommand, then env signals when Via is empty. MCP and a bare
+  `lade inject` use the same function. The same pattern can be a list of
+  bodies with different `when`.
 - **`.silence` hydration progress**: `silence: true` under `.` skips that
   rule's secret progress lines at hydrate time. Hydration itself is unchanged.
 - **`lade bench`**: times the incompressible path (parse all `lade.yml` files
@@ -24,22 +25,45 @@ Release notes are also published on [GitHub Releases](https://github.com/zifeo/l
   (`5s` by default). Errors sit on the next indented line. `--json` includes
   `total_ms` and `timeout_ms`. Secret values are not printed. Network acquire
   is not run.
+- **Claude-compatible preTool hosts**: `lade hook` keeps an explicit detect
+  path for Codex, Pi, and OpenCode, then rewrites with the same `updatedInput`
+  envelope as Claude Code. `lade install` / `status` cover
+  `~/.codex/hooks.json`, `~/.pi/agent/settings.json`, and
+  `~/.config/opencode/plugins/lade-pretool.js`.
 
 ### Changed
 
 - **`lade status --json` hooks object** (breaking): `hooks` is now
-  `{ "preexec": { shell, profile, installed }, "pretool": { cursor, claude } }`
+  `{ "preexec": { shell, profile, installed }, "pretool": { cursor, claude, codex, pi, opencode } }`
   with global and project paths. `ok` still depends only on preexec install,
   version, project config, and vault CLIs.
 - **UI mode**: `Hook` is renamed `Quiet`. Interactive only when a human
   `inject`/`approve` has both stdin and stderr as TTYs.
+- **`--pretool`**: `lade hook` rewrites matching commands to
+  `<lade> --pretool '…'` (the inject alias). `--pretool` wins over `LADE_VIA`
+  and sets `LADE_VIA=pretool` on the child command, symmetric with preexec
+  exporting `LADE_VIA=preexec`. Shell hooks still use the env var.
+- **Hook bin name**: `lade install` and match rewrites use argv[0]. `lade`
+  stays `lade`. A path invocation (`/opt/lade install`) uses `current_exe`.
+  Re-running `lade install` updates an existing hook that still has a path.
 
 ### Fixed
 
 - **`.when` ignores `CURSOR_VERSION`**: Cursor sets it in human terminals, so it
   must not select agent rules on `inject` / `mcp`.
+- **preTool envelope**: `CURSOR_VERSION` no longer wins over a `PreToolUse`
+  payload or an explicit Codex, Pi, or OpenCode detect path. Those hosts ignore
+  Cursor's `updated_input`.
+- **Already-injected hook rewrite**: stamp `--pretool` when the command is
+  already `lade inject` or `lade --pretool` without that flag, so `.when: agent`
+  still matches. Older `--via=pretool` and `LADE_VIA=pretool` prefixes still
+  count as stamped.
 - **`lade status` project preTool paths** walk toward `$HOME` and stop there, so
-  `~/.cursor/hooks.json` / `~/.claude/settings.json` stay in the global slot.
+  home-level agent hook files stay in the global slot.
+- **`lade status` latest version**: persist the GitHub tag from a successful
+  daily check so `status` can show it after shell use. If the fetch failed,
+  print when we last tried (`tried today at 14:25`, `tried yesterday at 09:05`)
+  instead of `not checked recently`.
 
 ## [0.16.0] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ shell session, CI job, or model context.
 - Open private network access through `kubectl`, `kubefwd`, Teleport `tsh`, or
   SSH only while the command runs.
 - Redact provider-resolved secrets from stdout and stderr.
-- Work from shells, CI, Cursor, and Claude Code.
+- Work from shells, CI, Cursor, Claude Code, Codex, Pi, and OpenCode.
 
 Compatible shells: [Fish](https://fishshell.com),
 [Bash](https://www.gnu.org/software/bash/), [Zsh](https://zsh.sourceforge.io).
@@ -218,17 +218,18 @@ putting secret values in the model context or chat transcript.
 
 ### Recommended usage: preTool hooks
 
-Cursor and Claude Code can call `lade hook` before shell commands. When an agent
-runs a matching command, Lade rewrites it through `lade inject`, resolves the
-configured access, and redacts provider-resolved secret values from stdout and
-stderr.
+Cursor, Claude Code, Codex, Pi, and OpenCode can call `lade hook` before shell
+commands. When an agent runs a matching command, Lade rewrites it through
+`lade inject`, resolves the configured access, and redacts provider-resolved
+secret values from stdout and stderr.
 
 The agent keeps using normal commands. Lade handles the sensitive part.
 
 `lade install` can add the hook for detected agents. The equivalent project
 configs are:
 
-#### Cursor
+<details>
+<summary>Cursor (<code>.cursor/hooks.json</code>)</summary>
 
 ```json
 {
@@ -237,7 +238,10 @@ configs are:
 }
 ```
 
-#### Claude Code
+</details>
+
+<details>
+<summary>Claude Code (<code>.claude/settings.json</code>)</summary>
 
 ```json
 {
@@ -251,6 +255,99 @@ configs are:
   }
 }
 ```
+
+</details>
+
+<details>
+<summary>Codex (<code>.codex/hooks.json</code>)</summary>
+
+After `lade install`, open `/hooks` in Codex and trust the Lade command. An
+untrusted hook or `[features].hooks = false` is a silent no-op. Global file:
+`~/.codex/hooks.json`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Pi (<code>.pi/settings.json</code>)</summary>
+
+Pi matches on `tool_name`, often lowercase `bash`. Global file:
+`~/.pi/agent/settings.json`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|bash",
+        "hooks": [{ "type": "command", "command": "lade hook" }]
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>OpenCode (<code>.opencode/plugins/lade-pretool.js</code>)</summary>
+
+Native OpenCode loads plugins, not Claude-style `hooks.json`. Global:
+`~/.config/opencode/plugins/`. The plugin runs `lade hook` on
+`tool.execute.before` and applies the rewritten command.
+
+```js
+import { spawnSync } from "node:child_process";
+
+const lade = process.env.LADE_BIN ?? "lade";
+
+export const LadePretool = async () => ({
+  "tool.execute.before": async (input, output) => {
+    const command = output.args?.command;
+    if (input.tool !== "bash" || typeof command !== "string") {
+      return;
+    }
+    const payload = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command },
+      hook_source: "opencode-plugin",
+    });
+    const result = spawnSync(lade, ["hook"], {
+      input: payload,
+      encoding: "utf8",
+      env: { ...process.env, OPENCODE: "1" },
+    });
+    if (result.status !== 0 || !result.stdout?.trim()) {
+      return;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      return;
+    }
+    const updated = parsed?.hookSpecificOutput?.updatedInput?.command;
+    if (typeof updated === "string") {
+      output.args.command = updated;
+    }
+  },
+});
+```
+
+</details>
 
 Cursor agents can also load the project skill in
 [.agents/skills/lade/SKILL.md](.agents/skills/lade/SKILL.md).
@@ -425,11 +522,13 @@ Options under `.` configure the matched command itself.
 ```
 
 `when` is `always` (default), `human`, or `agent`. Audience comes from
-`detect()`: `LADE_VIA=pretool` or `lade hook` is `agent`; `LADE_VIA=preexec` or
-`lade set`/`unset` is `human`; otherwise env signals (`AI_AGENT`, `CURSOR_AGENT`,
-`CLAUDECODE`, not `CURSOR_VERSION`) select `agent`, else `human`. The same
-pattern can be a YAML list of these blocks when `when` differs. `silence` is
-optional and skips that rule's secret progress lines at hydration.
+`detect()`: `--pretool` or `lade hook` is `agent`; `lade set`/`unset` is
+`human`. `--pretool` wins over `LADE_VIA`. `LADE_VIA` is the courier in the
+child command env (`preexec` from shell hooks, `pretool` from `--pretool`).
+Otherwise env signals (`AI_AGENT`, `CURSOR_AGENT`, `CLAUDECODE`, not
+`CURSOR_VERSION`) select `agent`, else `human`. The same pattern can be a
+YAML list of these blocks when `when` differs. `silence` is optional and
+skips that rule's secret progress lines at hydration.
 
 ```yaml
 "^git ":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,13 +103,16 @@ Network provider notes:
 
 ## 4. Via, Audience, UI
 
-Every invocation runs `audience::detect(command, stdin_tty, stderr_tty)`. That
-single function returns Via, Audience, and UiMode. TTY is an input; Quiet vs
+Every invocation runs `audience::detect(command, pretool, stdin_tty, stderr_tty)`.
+That single function returns Via, Audience, and UiMode. TTY is an input; Quiet vs
 Interactive is an output. Callers use `ctx.audience` for `.when` and
 `ctx.is_interactive()` for prompts.
 
-- **Via** (`LADE_VIA`): `preexec` (`lade set`/`unset`), `pretool` (`lade hook`
-  rewrite), or unset. An unknown value fails fast.
+- **Via**: `--pretool` wins, then `LADE_VIA`, then the subcommand (`set`/`unset` are
+  preexec, `hook` is pretool), else unset. An unknown `LADE_VIA` value fails
+  fast. Shell hooks export `LADE_VIA=preexec` into the user's command.
+  `lade hook` rewrites to `<bin> --pretool '…'` (`lade` when invoked as `lade`) and inject sets `LADE_VIA=pretool`
+  on the child.
 - **Audience** (`.when`): `human` / `agent`. Pretool is agent, preexec is human,
   unset falls back to env signals (`AI_AGENT`, `AGENT`, `CLAUDECODE`,
   `CURSOR_AGENT`, `COPILOT_MODEL`). `CURSOR_VERSION` is ignored: Cursor also
@@ -224,17 +227,17 @@ Use `lade status` for an active report (version, config, preexec and preTool hoo
 
 ### preTool path
 
-`lade hook` (`src/pretool/`) reads Cursor/Claude preToolUse JSON and rewrites a matching command into `LADE_VIA=pretool <lade> inject '…'`. Schemas: <https://cursor.com/docs/agent/hooks>, <https://code.claude.com/docs/en/hooks>.
+`lade hook` (`src/pretool/`) reads preToolUse JSON and rewrites a matching command into `<lade> --pretool '…'`. Envelope comes from the payload first: `PreToolUse` and explicit Codex/Pi/OpenCode signals use `hookSpecificOutput` + `updatedInput`. Cursor's `updated_input` is only for `CURSOR_VERSION` or `preToolUse`. `CURSOR_VERSION` is last because Cursor also sets it in other hosts' terminals.
 
-Disclaimers are not special-cased in `lade hook`. `lade inject` is the gate. The rewrite re-emits leading `LADE_APPROVE=...` before inject (`platform::split_env_prefix`).
+Disclaimers are not special-cased in `lade hook`. Inject is the gate (the `--pretool` alias is `lade inject`). The rewrite re-emits leading `LADE_APPROVE=...` (`platform::split_env_prefix`).
 
 ### Installing preTool hooks (`src/pretool/install/`)
 
-`lade install` offers to wire `lade hook` into agents present on the machine (`~/.cursor`, `~/.claude`). It writes the absolute `lade hook` command to global config (`~/.cursor/hooks.json`, `~/.claude/settings.json`). Project-local configs remain a copy-paste (README). `lade status` reports both global and project paths.
+`lade install` offers to wire `lade hook` into agents present on the machine (`~/.cursor`, `~/.claude`, `~/.codex`, `~/.pi`, `~/.config/opencode`). The bin name follows argv[0]: `lade install` writes `lade hook`; a path invocation writes that resolved `lade hook`. OpenCode gets a native plugin at `~/.config/opencode/plugins/lade-pretool.js`. Project-local configs remain a copy-paste (README). `lade status` reports both global and project paths. `lade hook` rewrites matches with the same bin name.
 
 ### Direct path
 
-When Via is unset (`lade inject`, `lade mcp`, `lade git …`), `detect()` uses env signals: `AI_AGENT` → `AGENT` → `CLAUDECODE=1` → `CURSOR_AGENT` → `COPILOT_MODEL`. `CURSOR_VERSION` is ignored because Cursor also sets it in human terminals. That classification selects `.when` rules and the fail-closed disclaimer wording.
+When Via is unset (`lade inject`, `lade mcp`, `lade git …`), `detect()` uses env signals: `AI_AGENT` → `AGENT` → `CLAUDECODE=1` → `CURSOR_AGENT` → `COPILOT_MODEL`. `CURSOR_VERSION` is ignored because Cursor also sets it in human terminals. That classification selects `.when` rules and the fail-closed disclaimer wording. Codex isolation is the pretool rewrite (`--pretool`), not an audience env signal.
 
 ### Exit codes
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -124,7 +124,7 @@ pub enum Command {
         /// The secret URI to resolve (e.g., op://vault/item/field)
         uri: String,
     },
-    /// Handle preToolUse for Cursor and Claude Code.
+    /// Handle preToolUse for Cursor, Claude Code, Codex, Pi, and OpenCode.
     Hook,
     /// Approve a pending disclaimer and run the command, using the code shown in
     /// the disclaimer message.
@@ -153,6 +153,11 @@ pub struct Args {
 
     #[clap(short, long, value_parser)]
     pub help: bool,
+
+    /// Stamp this invocation as preTool. Sets `LADE_VIA=pretool` on the child
+    /// command. Wins over `LADE_VIA`. Shell hooks still use the env var.
+    #[clap(long, global = true, default_value_t = false)]
+    pub pretool: bool,
 
     #[clap(subcommand)]
     pub command: Option<Command>,
@@ -190,5 +195,37 @@ mod tests {
     fn parse_timeout_rejects_zero_and_bare_number() {
         assert!(parse_timeout("0s").is_err());
         assert!(parse_timeout("5").is_err());
+    }
+
+    #[test]
+    fn pretool_before_inject() {
+        let args = Args::try_parse_from(["lade", "--pretool", "inject", "echo"]).unwrap();
+        assert!(args.pretool);
+        match args.command {
+            Some(Command::Inject(inject)) => assert_eq!(inject.commands, vec!["echo"]),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn pretool_before_alias() {
+        let args = Args::try_parse_from(["lade", "--pretool", "terraform", "apply"]).unwrap();
+        assert!(args.pretool);
+        match args.command {
+            Some(Command::InjectAlias(commands)) => {
+                assert_eq!(commands, vec!["terraform", "apply"])
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn pretool_before_mcp() {
+        let args = Args::try_parse_from(["lade", "--pretool", "mcp", "--", "acme"]).unwrap();
+        assert!(args.pretool);
+        match args.command {
+            Some(Command::Mcp(mcp)) => assert_eq!(mcp.argv, vec![OsString::from("acme")]),
+            other => panic!("{other:?}"),
+        }
     }
 }

--- a/src/audience.rs
+++ b/src/audience.rs
@@ -17,6 +17,19 @@ pub enum Via {
     Unset,
 }
 
+impl Via {
+    /// Value written to `LADE_VIA` on the child command. Preexec already
+    /// exports `preexec` into the shell; `--pretool` does the same for inject.
+    /// Unset means strip so a leftover parent value does not leak.
+    pub fn child_stamp(self) -> Option<&'static str> {
+        match self {
+            Via::Pretool => Some(LADE_VIA_PRETOOL),
+            Via::Preexec => Some(LADE_VIA_PREEXEC),
+            Via::Unset => None,
+        }
+    }
+}
+
 /// Whether this invocation may prompt on stdin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UiMode {
@@ -31,15 +44,16 @@ pub struct Detection {
     pub ui: UiMode,
 }
 
-/// Classify this invocation. `LADE_VIA` wins, then the subcommand, then agent
-/// env signals. UI is an output: Interactive only for human inject/approve with
-/// both stdin and stderr attached to a TTY.
+/// Classify this invocation. `--pretool` wins, then `LADE_VIA`, then the
+/// subcommand, then agent env signals. UI is an output: Interactive only for
+/// human inject/approve with both stdin and stderr attached to a TTY.
 pub fn detect(
     command: &Command,
+    pretool: bool,
     stdin_is_terminal: bool,
     stderr_is_terminal: bool,
 ) -> Result<Detection> {
-    let via = via(command)?;
+    let via = via(command, pretool)?;
     let audience = match via {
         Via::Pretool => Audience::Agent,
         Via::Preexec => Audience::Human,
@@ -63,7 +77,10 @@ pub fn detect(
     Ok(Detection { via, audience, ui })
 }
 
-fn via(command: &Command) -> Result<Via> {
+fn via(command: &Command, pretool: bool) -> Result<Via> {
+    if pretool {
+        return Ok(Via::Pretool);
+    }
     match std::env::var(LADE_VIA) {
         Ok(value) if value == LADE_VIA_PRETOOL => return Ok(Via::Pretool),
         Ok(value) if value == LADE_VIA_PREEXEC => return Ok(Via::Preexec),
@@ -158,7 +175,7 @@ mod tests {
                 })
                 .collect::<Vec<_>>(),
             || {
-                let d = detect(&inject(), true, true).unwrap();
+                let d = detect(&inject(), false, true, true).unwrap();
                 assert_eq!(d.via, Via::Pretool);
                 assert_eq!(d.audience, Audience::Agent);
                 assert_eq!(d.ui, UiMode::Quiet);
@@ -179,7 +196,7 @@ mod tests {
                 ("COPILOT_MODEL", None),
             ],
             || {
-                let d = detect(&inject(), true, true).unwrap();
+                let d = detect(&inject(), false, true, true).unwrap();
                 assert_eq!(d.via, Via::Preexec);
                 assert_eq!(d.audience, Audience::Human);
                 assert_eq!(d.ui, UiMode::Interactive);
@@ -188,9 +205,59 @@ mod tests {
     }
 
     #[test]
+    fn inject_via_flag_is_pretool_agent_quiet() {
+        temp_env::with_vars(cleared_signals(), || {
+            let d = detect(&inject(), true, true, true).unwrap();
+            assert_eq!(d.via, Via::Pretool);
+            assert_eq!(d.audience, Audience::Agent);
+            assert_eq!(d.ui, UiMode::Quiet);
+        });
+    }
+
+    #[test]
+    fn via_flag_on_status_is_pretool_agent() {
+        temp_env::with_vars(cleared_signals(), || {
+            let d = detect(
+                &Command::Status(crate::args::StatusCommand {
+                    all: false,
+                    json: false,
+                }),
+                true,
+                true,
+                true,
+            )
+            .unwrap();
+            assert_eq!(d.via, Via::Pretool);
+            assert_eq!(d.audience, Audience::Agent);
+            assert_eq!(d.ui, UiMode::Quiet);
+        });
+    }
+
+    #[test]
+    fn via_flag_wins_over_env() {
+        temp_env::with_vars(
+            cleared_signals()
+                .into_iter()
+                .map(|(k, v)| {
+                    if k == LADE_VIA {
+                        (k, Some(LADE_VIA_PREEXEC))
+                    } else {
+                        (k, v)
+                    }
+                })
+                .collect::<Vec<_>>(),
+            || {
+                let d = detect(&inject(), true, true, true).unwrap();
+                assert_eq!(d.via, Via::Pretool);
+                assert_eq!(d.audience, Audience::Agent);
+            },
+        );
+    }
+
+    #[test]
     fn set_is_preexec_human_quiet() {
         temp_env::with_vars(cleared_signals(), || {
-            let d = detect(&set_cmd(), true, true).unwrap();
+            let d = detect(&set_cmd(), false, true, true).unwrap();
             assert_eq!(d.via, Via::Preexec);
             assert_eq!(d.audience, Audience::Human);
             assert_eq!(d.ui, UiMode::Quiet);
@@ -200,7 +267,7 @@ mod tests {
     #[test]
     fn hook_is_pretool_agent_quiet() {
         temp_env::with_vars(cleared_signals(), || {
-            let d = detect(&Command::Hook, false, false).unwrap();
+            let d = detect(&Command::Hook, false, false, false).unwrap();
             assert_eq!(d.via, Via::Pretool);
             assert_eq!(d.audience, Audience::Agent);
             assert_eq!(d.ui, UiMode::Quiet);
@@ -220,7 +287,7 @@ mod tests {
                 ("CURSOR_VERSION", None),
             ],
             || {
-                let d = detect(&inject(), true, true).unwrap();
+                let d = detect(&inject(), false, true, true).unwrap();
                 assert_eq!(d.via, Via::Unset);
                 assert_eq!(d.audience, Audience::Agent);
                 assert_eq!(d.ui, UiMode::Quiet);
@@ -231,7 +298,7 @@ mod tests {
     #[test]
     fn empty_via_without_signal_inject_tty_is_human_interactive() {
         temp_env::with_vars(cleared_signals(), || {
-            let d = detect(&inject(), true, true).unwrap();
+            let d = detect(&inject(), false, true, true).unwrap();
             assert_eq!(d.via, Via::Unset);
             assert_eq!(d.audience, Audience::Human);
             assert_eq!(d.ui, UiMode::Interactive);
@@ -251,7 +318,7 @@ mod tests {
                 ("CURSOR_VERSION", Some("1.0")),
             ],
             || {
-                let d = detect(&inject(), true, true).unwrap();
+                let d = detect(&inject(), false, true, true).unwrap();
                 assert_eq!(d.via, Via::Unset);
                 assert_eq!(d.audience, Audience::Human);
                 assert_eq!(d.ui, UiMode::Interactive);
@@ -262,7 +329,7 @@ mod tests {
     #[test]
     fn invalid_via_fails() {
         temp_env::with_var(LADE_VIA, Some("nope"), || {
-            assert!(detect(&inject(), false, false).is_err());
+            assert!(detect(&inject(), false, false, false).is_err());
         });
     }
 
@@ -296,5 +363,12 @@ mod tests {
             ],
             || assert_eq!(agent_signal(), None),
         );
+    }
+
+    #[test]
+    fn child_stamp_matches_via() {
+        assert_eq!(Via::Pretool.child_stamp(), Some(LADE_VIA_PRETOOL));
+        assert_eq!(Via::Preexec.child_stamp(), Some(LADE_VIA_PREEXEC));
+        assert_eq!(Via::Unset.child_stamp(), None);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,9 +18,10 @@ pub struct InvocationContext {
 }
 
 impl InvocationContext {
-    pub fn from_command(command: &Command) -> Result<Self> {
+    pub fn from_command(command: &Command, pretool: bool) -> Result<Self> {
         Self::with_tty(
             command,
+            pretool,
             std::io::stdin().is_terminal(),
             std::io::stdout().is_terminal(),
             std::io::stderr().is_terminal(),
@@ -29,12 +30,13 @@ impl InvocationContext {
 
     pub fn with_tty(
         command: &Command,
+        pretool: bool,
         stdin_is_terminal: bool,
         stdout_is_terminal: bool,
         stderr_is_terminal: bool,
     ) -> Result<Self> {
         let Detection { via, audience, ui } =
-            audience::detect(command, stdin_is_terminal, stderr_is_terminal)?;
+            audience::detect(command, pretool, stdin_is_terminal, stderr_is_terminal)?;
         Ok(Self {
             via,
             audience,
@@ -82,6 +84,7 @@ mod tests {
                 &Command::Set(EvalCommand {
                     commands: vec!["x".into()],
                 }),
+                false,
                 true,
                 true,
                 true,
@@ -100,6 +103,7 @@ mod tests {
                 &Command::Unset(EvalCommand {
                     commands: vec!["x".into()],
                 }),
+                false,
                 true,
                 true,
                 true,
@@ -112,7 +116,7 @@ mod tests {
     #[test]
     fn inject_without_tty_is_quiet() {
         temp_env::with_vars(cleared(), || {
-            let ctx = InvocationContext::with_tty(&inject(), false, false, false).unwrap();
+            let ctx = InvocationContext::with_tty(&inject(), false, false, false, false).unwrap();
             assert_eq!(ctx.mode, UiMode::Quiet);
         });
     }
@@ -120,7 +124,7 @@ mod tests {
     #[test]
     fn inject_with_tty_is_interactive() {
         temp_env::with_vars(cleared(), || {
-            let ctx = InvocationContext::with_tty(&inject(), true, true, true).unwrap();
+            let ctx = InvocationContext::with_tty(&inject(), false, true, true, true).unwrap();
             assert_eq!(ctx.mode, UiMode::Interactive);
             assert_eq!(ctx.audience, Audience::Human);
         });
@@ -134,6 +138,7 @@ mod tests {
                     all: false,
                     json: false,
                 }),
+                false,
                 true,
                 true,
                 true,
@@ -146,9 +151,14 @@ mod tests {
     #[test]
     fn approve_is_quiet_without_tty() {
         temp_env::with_vars(cleared(), || {
-            let ctx =
-                InvocationContext::with_tty(&Command::Approve { code: None }, false, false, false)
-                    .unwrap();
+            let ctx = InvocationContext::with_tty(
+                &Command::Approve { code: None },
+                false,
+                false,
+                false,
+                false,
+            )
+            .unwrap();
             assert_eq!(ctx.mode, UiMode::Quiet);
         });
     }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -28,10 +28,18 @@ pub fn run(
     ctx: &crate::context::InvocationContext,
     shell: &str,
     command: &str,
-    env: HashMap<String, String>,
+    mut env: HashMap<String, String>,
     cwd: &Path,
     redactor: Option<Redactor>,
 ) -> Result<i32> {
+    match ctx.via.child_stamp() {
+        Some(value) => {
+            env.insert(crate::shell::LADE_VIA.to_string(), value.to_string());
+        }
+        None => {
+            env.remove(crate::shell::LADE_VIA);
+        }
+    }
     let mode = select_mode(
         redactor.is_some(),
         ctx.stdin_is_terminal,

--- a/src/global_config.rs
+++ b/src/global_config.rs
@@ -14,6 +14,10 @@ pub struct GlobalConfig {
     /// Never invent `Utc::now()` here: that skipped the real lookup for 24h.
     #[serde(default)]
     pub update_check: Option<DateTime<Utc>>,
+    /// Last GitHub latest tag we successfully fetched. Separate from
+    /// `update_check`, which is stamped even when the request fails.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
     pub user: Option<String>,
     #[serde(default)]
     pub cli_check: BTreeMap<String, DateTime<Utc>>,
@@ -41,6 +45,7 @@ impl GlobalConfig {
         } else {
             Ok(GlobalConfig {
                 update_check: None,
+                latest_version: None,
                 user: None,
                 cli_check: BTreeMap::new(),
             })
@@ -107,6 +112,7 @@ mod tests {
                 .block_on(async {
                     let config = GlobalConfig::load().await.unwrap();
                     assert!(config.update_check.is_some());
+                    assert_eq!(config.latest_version, None);
                 });
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn run() -> Result<()> {
         return Ok(());
     }
 
+    let pretool = args.pretool;
     let command = match args.command {
         Some(Command::InjectAlias(commands)) => Command::Inject(InjectCommand {
             no_mask: false,
@@ -88,7 +89,7 @@ async fn run() -> Result<()> {
         }
     };
 
-    let ctx = match InvocationContext::from_command(&command) {
+    let ctx = match InvocationContext::from_command(&command, pretool) {
         Ok(ctx) => ctx,
         Err(e) => {
             message_box::MessageBox::new()

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -36,7 +36,16 @@ pub async fn run(
         }
         None => {
             info!("mcp started transport=stdio");
-            run_stdio(command.argv, access.env.clone(), current_dir).await
+            let mut env = access.env.clone();
+            match ctx.via.child_stamp() {
+                Some(value) => {
+                    env.insert(crate::shell::LADE_VIA.to_string(), value.to_string());
+                }
+                None => {
+                    env.remove(crate::shell::LADE_VIA);
+                }
+            }
+            run_stdio(command.argv, env, current_dir).await
         }
     };
     access.cleanup()?;

--- a/src/pretool/install/config.rs
+++ b/src/pretool/install/config.rs
@@ -8,15 +8,27 @@ use std::path::{Path, PathBuf};
 pub(super) enum Agent {
     Cursor,
     Claude,
+    Codex,
+    Pi,
+    OpenCode,
 }
 
-pub(super) const AGENTS: [Agent; 2] = [Agent::Cursor, Agent::Claude];
+pub(super) const AGENTS: [Agent; 5] = [
+    Agent::Cursor,
+    Agent::Claude,
+    Agent::Codex,
+    Agent::Pi,
+    Agent::OpenCode,
+];
 
 impl Agent {
     pub(super) fn name(self) -> &'static str {
         match self {
             Agent::Cursor => "Cursor",
             Agent::Claude => "Claude Code",
+            Agent::Codex => "Codex",
+            Agent::Pi => "Pi",
+            Agent::OpenCode => "OpenCode",
         }
     }
 
@@ -24,6 +36,13 @@ impl Agent {
         match self {
             Agent::Cursor => home.join(".cursor").join("hooks.json"),
             Agent::Claude => home.join(".claude").join("settings.json"),
+            Agent::Codex => home.join(".codex").join("hooks.json"),
+            Agent::Pi => home.join(".pi").join("agent").join("settings.json"),
+            Agent::OpenCode => home
+                .join(".config")
+                .join("opencode")
+                .join("plugins")
+                .join("lade-pretool.js"),
         }
     }
 
@@ -31,12 +50,34 @@ impl Agent {
         match self {
             Agent::Cursor => home.join(".cursor"),
             Agent::Claude => home.join(".claude"),
+            Agent::Codex => home.join(".codex"),
+            Agent::Pi => home.join(".pi"),
+            Agent::OpenCode => home.join(".config").join("opencode"),
+        }
+    }
+
+    fn shell_matcher(self) -> &'static str {
+        match self {
+            Agent::Pi => "Bash|bash",
+            _ => "Bash",
+        }
+    }
+
+    /// Claude-compat `hooks.json` left by an older install. Native OpenCode
+    /// ignores it; uninstall still strips our entry.
+    pub(super) fn legacy_json_path(self, home: &Path) -> Option<PathBuf> {
+        match self {
+            Agent::OpenCode => Some(home.join(".config").join("opencode").join("hooks.json")),
+            _ => None,
         }
     }
 
     pub(super) fn has_hook(self, existing: &str) -> Result<bool> {
         if existing.trim().is_empty() {
             return Ok(false);
+        }
+        if matches!(self, Agent::OpenCode) {
+            return Ok(is_lade_plugin(existing));
         }
         let root = parse_root(existing, self)?;
         let found = match self {
@@ -45,16 +86,62 @@ impl Agent {
                 .and_then(Value::as_array)
                 .map(|a| a.iter().any(command_is_lade_hook))
                 .unwrap_or(false),
-            Agent::Claude => root
+            Agent::Claude | Agent::Codex | Agent::Pi => root
                 .pointer("/hooks/PreToolUse")
                 .and_then(Value::as_array)
-                .map(|a| a.iter().any(claude_matcher_has_hook))
+                .map(|a| a.iter().any(matcher_has_hook))
                 .unwrap_or(false),
+            Agent::OpenCode => false,
         };
         Ok(found)
     }
 
+    pub(super) fn hook_uses_command(self, existing: &str, command: &str) -> Result<bool> {
+        if !self.has_hook(existing)? {
+            return Ok(false);
+        }
+        if matches!(self, Agent::OpenCode) {
+            return Ok(existing.trim_end() == opencode_plugin_body(command).trim_end());
+        }
+        let root = parse_root(existing, self)?;
+        Ok(match self {
+            Agent::Cursor => root
+                .pointer("/hooks/preToolUse")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    entries.iter().any(|entry| {
+                        command_is_lade_hook(entry)
+                            && entry.get("command").and_then(Value::as_str) == Some(command)
+                    })
+                })
+                .unwrap_or(false),
+            Agent::Claude | Agent::Codex | Agent::Pi => root
+                .pointer("/hooks/PreToolUse")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    entries.iter().any(|entry| {
+                        entry
+                            .get("hooks")
+                            .and_then(Value::as_array)
+                            .map(|hooks| {
+                                hooks.iter().any(|hook| {
+                                    command_is_lade_hook(hook)
+                                        && hook.get("command").and_then(Value::as_str)
+                                            == Some(command)
+                                })
+                            })
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false),
+            Agent::OpenCode => false,
+        })
+    }
+
     pub(super) fn merge(self, existing: &str, command: &str) -> Result<String> {
+        if matches!(self, Agent::OpenCode) {
+            return Ok(opencode_plugin_body(command));
+        }
         let mut root = parse_root(existing, self)?;
         let obj = root
             .as_object_mut()
@@ -71,11 +158,14 @@ impl Agent {
                     .or_insert_with(|| json!([]))
                     .as_array_mut()
                     .context("\"preToolUse\" must be an array")?;
-                if !arr.iter().any(command_is_lade_hook) {
+                if let Some(entry) = arr.iter_mut().find(|e| command_is_lade_hook(e)) {
+                    entry["command"] = json!(command);
+                } else {
                     arr.push(json!({ "command": command, "matcher": "Shell" }));
                 }
             }
-            Agent::Claude => {
+            Agent::Claude | Agent::Codex | Agent::Pi => {
+                let matcher = self.shell_matcher();
                 let arr = obj
                     .entry("hooks")
                     .or_insert_with(|| json!({}))
@@ -85,13 +175,22 @@ impl Agent {
                     .or_insert_with(|| json!([]))
                     .as_array_mut()
                     .context("\"PreToolUse\" must be an array")?;
-                if !arr.iter().any(claude_matcher_has_hook) {
+                if let Some(entry) = arr.iter_mut().find(|e| matcher_has_hook(e)) {
+                    if let Some(hooks) = entry.get_mut("hooks").and_then(Value::as_array_mut) {
+                        for hook in hooks.iter_mut() {
+                            if command_is_lade_hook(hook) {
+                                hook["command"] = json!(command);
+                            }
+                        }
+                    }
+                } else {
                     arr.push(json!({
-                        "matcher": "Bash",
+                        "matcher": matcher,
                         "hooks": [{ "type": "command", "command": command }]
                     }));
                 }
             }
+            Agent::OpenCode => {}
         }
         to_pretty(&root)
     }
@@ -109,7 +208,8 @@ impl Agent {
                         arr.retain(|e| !command_is_lade_hook(e));
                     }
                 }
-                Agent::Claude => {
+                Agent::Claude | Agent::Codex | Agent::Pi | Agent::OpenCode => {
+                    // OpenCode here is leftover Claude-compat hooks.json only.
                     if let Some(arr) = obj
                         .get_mut("hooks")
                         .and_then(|h| h.get_mut("PreToolUse"))
@@ -138,7 +238,7 @@ impl Agent {
     }
 }
 
-fn claude_matcher_has_hook(entry: &Value) -> bool {
+fn matcher_has_hook(entry: &Value) -> bool {
     entry
         .get("hooks")
         .and_then(Value::as_array)
@@ -152,6 +252,10 @@ fn command_is_lade_hook(entry: &Value) -> bool {
         .and_then(Value::as_str)
         .map(is_lade_hook)
         .unwrap_or(false)
+}
+
+pub(super) fn is_lade_plugin(content: &str) -> bool {
+    content.contains("lade hook") || content.contains("[\"hook\"]")
 }
 
 /// Recognize both `lade hook` and an absolute path like `/usr/local/bin/lade
@@ -178,4 +282,53 @@ fn to_pretty(value: &Value) -> Result<String> {
     // Relies on serde_json's `preserve_order` feature so rewriting a user's
     // config appends our entry without reordering their existing keys.
     Ok(format!("{}\n", serde_json::to_string_pretty(value)?))
+}
+
+fn opencode_plugin_body(command: &str) -> String {
+    let bin = command
+        .split_whitespace()
+        .next()
+        .unwrap_or("lade")
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'");
+    format!(
+        r#"import {{ spawnSync }} from "node:child_process";
+
+const lade = process.env.LADE_BIN ?? "{bin}";
+
+// OpenCode loads every exported function in this file and calls it for hooks.
+export const LadePretool = async () => ({{
+  "tool.execute.before": async (input, output) => {{
+    const command = output.args?.command;
+    if (input.tool !== "bash" || typeof command !== "string") {{
+      return;
+    }}
+    const payload = JSON.stringify({{
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: {{ command }},
+      hook_source: "opencode-plugin",
+    }});
+    const result = spawnSync(lade, ["hook"], {{
+      input: payload,
+      encoding: "utf8",
+      env: {{ ...process.env, OPENCODE: "1" }},
+    }});
+    if (result.status !== 0 || !result.stdout?.trim()) {{
+      return;
+    }}
+    let parsed;
+    try {{
+      parsed = JSON.parse(result.stdout);
+    }} catch {{
+      return;
+    }}
+    const updated = parsed?.hookSpecificOutput?.updatedInput?.command;
+    if (typeof updated === "string") {{
+      output.args.command = updated;
+    }}
+  }},
+}});
+"#
+    )
 }

--- a/src/pretool/install/mod.rs
+++ b/src/pretool/install/mod.rs
@@ -1,12 +1,11 @@
 //! Optional installation of the `lade hook` interceptor into the agents that
-//! support `preToolUse` shell hooks (Cursor, Claude Code).
+//! support `preToolUse` shell hooks (Cursor, Claude Code, Codex, Pi, OpenCode).
 //!
 //! `lade install` is a global, once-only operation, so these hooks are written
 //! to the agents' global config (`~/.cursor/hooks.json`,
-//! `~/.claude/settings.json`). We only act when the agent's home dir already
-//! exists (i.e. the agent is actually used) and never overwrite unrelated
-//! settings: the config is parsed, our entry merged idempotently (see
-//! `config.rs`), and removed symmetrically on `lade uninstall`.
+//! `~/.claude/settings.json`, `~/.codex/hooks.json`, `~/.pi/agent/settings.json`,
+//! `~/.config/opencode/plugins/lade-pretool.js`). We only act when the agent's
+//! home dir already exists and never overwrite unrelated settings.
 
 mod config;
 #[cfg(test)]
@@ -28,9 +27,8 @@ fn home_dir() -> Result<PathBuf> {
         .context("cannot determine home directory")
 }
 
-fn hook_command() -> Result<String> {
-    let exe = std::env::current_exe()?;
-    Ok(format!("{} hook", exe.display()))
+fn hook_command() -> String {
+    format!("{} hook", crate::pretool::invoked_lade_bin())
 }
 
 fn tilde(path: &Path, home: &Path) -> String {
@@ -63,7 +61,7 @@ fn report(results: Vec<String>) {
 /// Offer to install the `lade hook` interceptor for every agent detected on the
 /// machine. `may_prompt` must be true only when both stdin and stderr are TTYs.
 pub fn install(may_prompt: bool) -> Result<()> {
-    let command = hook_command()?;
+    let command = hook_command();
     let home = home_dir()?;
     let mut results = Vec::new();
 
@@ -74,7 +72,23 @@ pub fn install(may_prompt: bool) -> Result<()> {
         let path = agent.config_path(&home);
         let existing = fs::read_to_string(&path).unwrap_or_default();
         if agent.has_hook(&existing)? {
-            results.push(format!("{}: hook already present", agent.name()));
+            if agent.hook_uses_command(&existing, &command)? {
+                results.push(format!("{}: hook already present", agent.name()));
+                continue;
+            }
+            if !may_prompt {
+                results.push(format!(
+                    "{}: detected — re-run `lade install` in a terminal to update its hook",
+                    agent.name()
+                ));
+                continue;
+            }
+            fs::write(&path, agent.merge(&existing, &command)?)?;
+            results.push(format!(
+                "{}: hook updated in {}",
+                agent.name(),
+                tilde(&path, &home)
+            ));
             continue;
         }
         if !may_prompt {
@@ -85,6 +99,9 @@ pub fn install(may_prompt: bool) -> Result<()> {
             continue;
         }
         if confirm(agent.name(), &tilde(&path, &home))? {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
             fs::write(&path, agent.merge(&existing, &command)?)?;
             results.push(format!(
                 "{}: hook installed in {}",
@@ -107,14 +124,19 @@ pub fn uninstall() -> Result<()> {
 
     for agent in AGENTS {
         let path = agent.config_path(&home);
-        let existing = match fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(_) => continue,
-        };
-        if !agent.has_hook(&existing)? {
+        let existing = fs::read_to_string(&path).unwrap_or_default();
+        let legacy = leftover_json_hook(agent, &home)?;
+        if !agent.has_hook(&existing)? && legacy.is_none() {
             continue;
         }
-        fs::write(&path, agent.remove(&existing)?)?;
+        if matches!(agent, config::Agent::OpenCode) {
+            let _ = fs::remove_file(&path);
+        } else if agent.has_hook(&existing)? {
+            fs::write(&path, agent.remove(&existing)?)?;
+        }
+        if let Some((legacy_path, content)) = legacy {
+            fs::write(&legacy_path, agent.remove(&content)?)?;
+        }
         results.push(format!(
             "{}: hook removed from {}",
             agent.name(),
@@ -142,14 +164,20 @@ pub struct PretoolAgentStatus {
 pub struct PretoolStatus {
     pub cursor: PretoolAgentStatus,
     pub claude: PretoolAgentStatus,
+    pub codex: PretoolAgentStatus,
+    pub pi: PretoolAgentStatus,
+    pub opencode: PretoolAgentStatus,
 }
 
-/// Global and project-local `lade hook` entries for Cursor and Claude Code.
+/// Global and project-local `lade hook` entries for supported agents.
 pub fn inspect(cwd: &Path) -> Result<PretoolStatus> {
     let home = home_dir()?;
     Ok(PretoolStatus {
         cursor: inspect_agent(config::Agent::Cursor, &home, cwd)?,
         claude: inspect_agent(config::Agent::Claude, &home, cwd)?,
+        codex: inspect_agent(config::Agent::Codex, &home, cwd)?,
+        pi: inspect_agent(config::Agent::Pi, &home, cwd)?,
+        opencode: inspect_agent(config::Agent::OpenCode, &home, cwd)?,
     })
 }
 
@@ -176,8 +204,18 @@ fn hook_present(path: &Path, agent: config::Agent) -> Result<bool> {
     }
 }
 
+fn leftover_json_hook(agent: config::Agent, home: &Path) -> Result<Option<(PathBuf, String)>> {
+    let Some(path) = agent.legacy_json_path(home) else {
+        return Ok(None);
+    };
+    match fs::read_to_string(&path) {
+        Ok(content) if config::Agent::Claude.has_hook(&content)? => Ok(Some((path, content))),
+        _ => Ok(None),
+    }
+}
+
 /// Walk from `cwd` toward `$HOME` looking for a project-local hook file.
-/// `$HOME/.cursor/hooks.json` (and Claude's home settings) stay in `global`.
+/// Home-level agent configs stay in `global`.
 fn find_project(agent: config::Agent, home: &Path, cwd: &Path) -> Result<(PathBuf, bool)> {
     let mut dir = cwd.to_path_buf();
     loop {
@@ -208,6 +246,16 @@ fn project_files(agent: config::Agent, dir: &Path) -> Vec<PathBuf> {
             dir.join(".claude").join("settings.local.json"),
             dir.join(".claude").join("settings.json"),
         ],
+        config::Agent::Codex => vec![dir.join(".codex").join("hooks.json")],
+        config::Agent::Pi => vec![
+            dir.join(".pi").join("settings.json"),
+            dir.join(".pi").join("hooks.json"),
+        ],
+        config::Agent::OpenCode => vec![
+            dir.join(".opencode")
+                .join("plugins")
+                .join("lade-pretool.js"),
+        ],
     }
 }
 
@@ -215,5 +263,11 @@ fn canonical_project_path(agent: config::Agent, cwd: &Path) -> PathBuf {
     match agent {
         config::Agent::Cursor => cwd.join(".cursor").join("hooks.json"),
         config::Agent::Claude => cwd.join(".claude").join("settings.json"),
+        config::Agent::Codex => cwd.join(".codex").join("hooks.json"),
+        config::Agent::Pi => cwd.join(".pi").join("settings.json"),
+        config::Agent::OpenCode => cwd
+            .join(".opencode")
+            .join("plugins")
+            .join("lade-pretool.js"),
     }
 }

--- a/src/pretool/install/tests.rs
+++ b/src/pretool/install/tests.rs
@@ -33,6 +33,20 @@ fn cursor_merge_is_idempotent() {
     let twice = Agent::Cursor.merge(&once, "lade hook").unwrap();
     let v: Value = serde_json::from_str(&twice).unwrap();
     assert_eq!(v["hooks"]["preToolUse"].as_array().unwrap().len(), 1);
+    assert_eq!(v["hooks"]["preToolUse"][0]["command"], "lade hook");
+}
+
+#[test]
+fn hook_uses_command_distinguishes_bin() {
+    let absolute = Agent::Cursor.merge("", CMD).unwrap();
+    assert!(Agent::Cursor.hook_uses_command(&absolute, CMD).unwrap());
+    assert!(
+        !Agent::Cursor
+            .hook_uses_command(&absolute, "lade hook")
+            .unwrap()
+    );
+    let bare = Agent::Cursor.merge(&absolute, "lade hook").unwrap();
+    assert!(Agent::Cursor.hook_uses_command(&bare, "lade hook").unwrap());
 }
 
 #[test]
@@ -81,6 +95,10 @@ fn claude_merge_is_idempotent() {
     let twice = Agent::Claude.merge(&once, "lade hook").unwrap();
     let v: Value = serde_json::from_str(&twice).unwrap();
     assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        v["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "lade hook"
+    );
 }
 
 #[test]
@@ -111,6 +129,82 @@ fn claude_remove_prunes_only_our_matcher() {
 fn has_hook_false_on_empty() {
     assert!(!Agent::Cursor.has_hook("").unwrap());
     assert!(!Agent::Claude.has_hook("   ").unwrap());
+    assert!(!Agent::Codex.has_hook("").unwrap());
+    assert!(!Agent::Pi.has_hook("").unwrap());
+    assert!(!Agent::OpenCode.has_hook("").unwrap());
+}
+
+#[test]
+fn pi_merge_uses_bash_or_bash_matcher() {
+    let out = Agent::Pi.merge("", CMD).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["hooks"]["PreToolUse"][0]["matcher"], "Bash|bash");
+    assert!(Agent::Pi.has_hook(&out).unwrap());
+}
+
+#[test]
+fn opencode_merge_writes_native_plugin() {
+    let out = Agent::OpenCode.merge("", CMD).unwrap();
+    assert!(out.contains("export const LadePretool"));
+    assert!(out.contains("[\"hook\"]"));
+    assert!(out.contains("updatedInput"));
+    assert!(out.contains(CMD.split_whitespace().next().unwrap()));
+    assert!(Agent::OpenCode.has_hook(&out).unwrap());
+}
+
+#[test]
+fn opencode_config_path_is_plugin() {
+    let home = std::path::Path::new("/tmp");
+    let path = Agent::OpenCode.config_path(home);
+    assert!(path.ends_with("plugins/lade-pretool.js"));
+}
+
+#[test]
+fn codex_merge_from_empty_adds_bash_matcher() {
+    let out = Agent::Codex.merge("", CMD).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["matcher"], "Bash");
+    assert_eq!(arr[0]["hooks"][0]["type"], "command");
+    assert_eq!(arr[0]["hooks"][0]["command"], CMD);
+    assert!(Agent::Codex.has_hook(&out).unwrap());
+}
+
+#[test]
+fn codex_merge_is_idempotent() {
+    let once = Agent::Codex.merge("", CMD).unwrap();
+    let twice = Agent::Codex.merge(&once, "lade hook").unwrap();
+    let v: Value = serde_json::from_str(&twice).unwrap();
+    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        v["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "lade hook"
+    );
+}
+
+#[test]
+fn codex_merge_preserves_existing_hooks() {
+    let existing = r#"{"description":"repo","hooks":{"PreToolUse":[{"matcher":"apply_patch","hooks":[{"type":"command","command":"guard"}]}]}}"#;
+    let out = Agent::Codex.merge(existing, CMD).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["description"], "repo");
+    let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    assert!(arr.iter().any(|e| e["matcher"] == "apply_patch"));
+    assert!(arr.iter().any(|e| e["matcher"] == "Bash"));
+}
+
+#[test]
+fn codex_remove_prunes_only_our_matcher() {
+    let existing = r#"{"hooks":{"PreToolUse":[{"matcher":"apply_patch","hooks":[{"type":"command","command":"guard"}]}]}}"#;
+    let merged = Agent::Codex.merge(existing, CMD).unwrap();
+    let cleaned = Agent::Codex.remove(&merged).unwrap();
+    let v: Value = serde_json::from_str(&cleaned).unwrap();
+    let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["matcher"], "apply_patch");
+    assert!(!Agent::Codex.has_hook(&cleaned).unwrap());
 }
 
 #[test]
@@ -162,4 +256,41 @@ fn find_project_finds_repo_hooks_before_home() {
     let (path, installed) = super::find_project(Agent::Cursor, home.path(), &repo).unwrap();
     assert!(installed);
     assert_eq!(path, repo.join(".cursor").join("hooks.json"));
+}
+
+#[test]
+fn find_project_does_not_treat_home_codex_as_project() {
+    let home = tempfile::tempdir().unwrap();
+    let repo = home.path().join("proj");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+    std::fs::write(
+        home.path().join(".codex").join("hooks.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"lade hook"}]}]}}"#,
+    )
+    .unwrap();
+    let (path, installed) = super::find_project(Agent::Codex, home.path(), &repo).unwrap();
+    assert!(!installed);
+    assert_eq!(path, repo.join(".codex").join("hooks.json"));
+}
+
+#[test]
+fn find_project_finds_repo_codex_hooks_before_home() {
+    let home = tempfile::tempdir().unwrap();
+    let repo = home.path().join("proj");
+    std::fs::create_dir_all(repo.join(".codex")).unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+    std::fs::write(
+        home.path().join(".codex").join("hooks.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"lade hook"}]}]}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join(".codex").join("hooks.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"lade hook"}]}]}}"#,
+    )
+    .unwrap();
+    let (path, installed) = super::find_project(Agent::Codex, home.path(), &repo).unwrap();
+    assert!(installed);
+    assert_eq!(path, repo.join(".codex").join("hooks.json"));
 }

--- a/src/pretool/mod.rs
+++ b/src/pretool/mod.rs
@@ -1,20 +1,28 @@
 /*
-preToolUse handler for Cursor and Claude Code (`lade hook`).
+preToolUse handler for Cursor, Claude Code, and Codex (`lade hook`).
 
 `detect()` classifies this process as Via::Pretool / Audience::Agent. Matching
-commands are rewritten into `LADE_VIA=pretool … inject '…'` so the child inject
-keeps that classification. Disclaimer enforcement lives in `lade inject`.
+commands are rewritten into `<lade> --pretool '…'` (the inject alias) so the
+child keeps that classification and gets `LADE_VIA=pretool` in its env.
+Disclaimer enforcement lives in inject.
 
 # Cursor preToolUse — https://cursor.com/docs/agent/hooks (verified June 2026)
 - Env: `CURSOR_VERSION`, `CURSOR_PROJECT_DIR`
 - Input: `{"tool_name": "Shell", "tool_input": {"command": "..."}, "hook_event_name": "preToolUse", ...}`
 - Output: `{"permission": "allow", "updated_input": {...}}`
 
-# Claude Code PreToolUse — https://code.claude.com/docs/en/hooks (verified June 2026)
-- Env: `CLAUDE_PROJECT_DIR`
-- Input: `{"tool_name": "Bash", "tool_input": {"command": "..."}, "hook_event_name": "PreToolUse", ...}`
+# Claude-compatible PreToolUse (Claude Code, Codex, Pi, OpenCode)
+- Claude: `CLAUDE_PROJECT_DIR` — https://code.claude.com/docs/en/hooks
+- Codex: `CODEX_THREAD_ID` / `CODEX_SANDBOX` / `CODEX_HOME`, plus `turn_id`/`model`
+  — https://developers.openai.com/codex/hooks
+- Pi: `PI_HOME` / `PI_CODING_AGENT`, payload `tool_name` is often `bash`
+- OpenCode: `OPENCODE` / `OPENCODE_DIR`, or `hook_source=opencode-plugin`
+- Input: `{"tool_name": "Bash"|"bash", "tool_input": {"command": "..."},
+  "hook_event_name": "PreToolUse", ...}`
 - Output: `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
-  "permissionDecision": "allow", "updatedInput": {...}}}`
+  "permissionDecision": "allow", "updatedInput": {...}}}`. Exit 0 with no
+  stdout allows the original command. Shell tools match as `Bash` (or `bash`
+  on Pi).
 */
 
 pub mod install;
@@ -27,13 +35,43 @@ use crate::config::{Audience, Config};
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::env;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
-use platform::{detect_platform, extract_command, is_already_injected, split_env_prefix};
+use platform::{
+    detect_platform, extract_command, has_pretool_stamp, is_already_injected, split_env_prefix,
+};
 use response::{format_allow, format_modify};
 
+fn pretool_flag() -> &'static str {
+    "--pretool"
+}
+
+/// Bin name for hook install and match rewrites.
+/// `lade install` / `lade hook` stay `lade`. A path in argv[0] uses current_exe.
+pub(crate) fn invoked_lade_bin() -> String {
+    invoked_lade_bin_from(env::args_os().next(), env::current_exe().ok())
+}
+
+pub(crate) fn invoked_lade_bin_from(
+    argv0: Option<OsString>,
+    current_exe: Option<PathBuf>,
+) -> String {
+    let argv0 = argv0.unwrap_or_default();
+    let path = Path::new(&argv0);
+    if !argv0.is_empty() && path.file_name() == Some(path.as_os_str()) {
+        return path.to_str().unwrap_or("lade").to_string();
+    }
+    current_exe
+        .and_then(|p| p.to_str().map(str::to_string))
+        .or_else(|| argv0.to_str().map(str::to_string))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "lade".to_string())
+}
+
 pub fn handle(config: &Config, input: &str, audience: Audience) -> Result<String> {
-    let platform = detect_platform()?;
     let parsed: Value = serde_json::from_str(input).unwrap_or(json!({}));
+    let platform = detect_platform(&parsed)?;
 
     let raw = match extract_command(&parsed) {
         Some(cmd) => cmd,
@@ -41,11 +79,21 @@ pub fn handle(config: &Config, input: &str, audience: Audience) -> Result<String
     };
 
     // Keep any leading `LADE_APPROVE=...` (or other env assignments) so the
-    // approval prefix reaches the wrapped `lade inject` process.
+    // approval prefix reaches the wrapped process.
     let (env_prefix, command) = split_env_prefix(&raw);
+    let tool_input = parsed.get("tool_input").cloned().unwrap_or(json!({}));
 
     if is_already_injected(&command) {
-        return Ok(format_allow(&platform));
+        if has_pretool_stamp(&env_prefix, &command) {
+            return Ok(format_allow(&platform));
+        }
+        let stamped = insert_pretool_flag(&command);
+        let rewritten = if env_prefix.is_empty() {
+            stamped
+        } else {
+            format!("{} {}", env_prefix, stamped)
+        };
+        return Ok(format_modify(&platform, &tool_input, &rewritten));
     }
 
     let matches = config.collect_for(&command, audience);
@@ -53,21 +101,26 @@ pub fn handle(config: &Config, input: &str, audience: Audience) -> Result<String
         return Ok(format_allow(&platform));
     }
 
-    let lade_bin = env::current_exe()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "lade".to_string());
+    let lade_bin = invoked_lade_bin();
     let escaped = command.replace('\'', "'\\''");
-    let stamp = format!(
-        "{}={}",
-        crate::shell::LADE_VIA,
-        crate::shell::LADE_VIA_PRETOOL
-    );
+    let wrapped = format!("{} {} '{}'", lade_bin, pretool_flag(), escaped);
     let new_command = if env_prefix.is_empty() {
-        format!("{} {} inject '{}'", stamp, lade_bin, escaped)
+        wrapped
     } else {
-        format!("{} {} {} inject '{}'", env_prefix, stamp, lade_bin, escaped)
+        format!("{} {}", env_prefix, wrapped)
     };
-    let tool_input = parsed.get("tool_input").cloned().unwrap_or(json!({}));
-
     Ok(format_modify(&platform, &tool_input, &new_command))
+}
+
+fn insert_pretool_flag(command: &str) -> String {
+    let mut parts = command.splitn(2, char::is_whitespace);
+    let Some(bin) = parts.next() else {
+        return command.to_string();
+    };
+    let rest = parts.next().unwrap_or("");
+    if rest.is_empty() {
+        format!("{} {}", bin, pretool_flag())
+    } else {
+        format!("{} {} {}", bin, pretool_flag(), rest)
+    }
 }

--- a/src/pretool/platform.rs
+++ b/src/pretool/platform.rs
@@ -6,22 +6,77 @@ use std::env;
 pub(super) enum Platform {
     Cursor,
     ClaudeCode,
+    Codex,
+    Pi,
+    OpenCode,
 }
 
-/// Detect the host agent from its hook environment. Cursor sets `CURSOR_VERSION`
-/// (<https://cursor.com/docs/agent/hooks#environment-variables>); Claude Code
-/// sets `CLAUDE_PROJECT_DIR` (<https://code.claude.com/docs/en/hooks>).
-pub(super) fn detect_platform() -> Result<Platform> {
-    if env::var("CURSOR_VERSION").is_ok() {
-        return Ok(Platform::Cursor);
+const CODEX_ENV: [&str; 3] = ["CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_HOME"];
+const PI_ENV: [&str; 2] = ["PI_HOME", "PI_CODING_AGENT"];
+const OPENCODE_ENV: [&str; 2] = ["OPENCODE", "OPENCODE_DIR"];
+
+/// Detect the host agent from payload, then hook environment. `CURSOR_VERSION`
+/// is last among env signals: Cursor also sets it in other hosts' terminals,
+/// and a `PreToolUse` payload must keep the Claude `updatedInput` envelope.
+pub(super) fn detect_platform(input: &Value) -> Result<Platform> {
+    if is_codex(input) {
+        return Ok(Platform::Codex);
     }
-    if env::var("CLAUDE_PROJECT_DIR").is_ok() {
+    if is_opencode(input) {
+        return Ok(Platform::OpenCode);
+    }
+    if is_pi(input) {
+        return Ok(Platform::Pi);
+    }
+    if env::var("CLAUDE_PROJECT_DIR").is_ok() || is_pretool_use(input) {
         return Ok(Platform::ClaudeCode);
     }
+    if env::var("CURSOR_VERSION").is_ok()
+        || input.get("hook_event_name").and_then(Value::as_str) == Some("preToolUse")
+    {
+        return Ok(Platform::Cursor);
+    }
     anyhow::bail!(
-        "Unknown platform: neither CURSOR_VERSION nor CLAUDE_PROJECT_DIR is set. \
-         lade hook only supports Cursor and Claude Code."
+        "Unknown platform: none of CURSOR_VERSION, CLAUDE_PROJECT_DIR, \
+         CODEX_THREAD_ID, CODEX_SANDBOX, CODEX_HOME, PI_HOME, PI_CODING_AGENT, \
+         OPENCODE, or OPENCODE_DIR is set. lade hook supports Cursor, \
+         Claude Code, Codex, Pi, and OpenCode."
     )
+}
+
+fn is_codex(input: &Value) -> bool {
+    CODEX_ENV.iter().any(|key| env::var(key).is_ok()) || is_codex_payload(input)
+}
+
+/// Codex documents `turn_id` and `model` as PreToolUse extensions.
+fn is_codex_payload(input: &Value) -> bool {
+    is_pretool_use(input)
+        && (input.get("turn_id").and_then(Value::as_str).is_some()
+            || input.get("model").and_then(Value::as_str).is_some())
+}
+
+fn is_pi(input: &Value) -> bool {
+    PI_ENV.iter().any(|key| env::var(key).is_ok()) || is_pi_payload(input)
+}
+
+fn is_pi_payload(input: &Value) -> bool {
+    is_pretool_use(input)
+        && input
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| name == "bash")
+}
+
+fn is_opencode(input: &Value) -> bool {
+    OPENCODE_ENV.iter().any(|key| env::var(key).is_ok()) || is_opencode_payload(input)
+}
+
+fn is_opencode_payload(input: &Value) -> bool {
+    input.get("hook_source").and_then(Value::as_str) == Some("opencode-plugin")
+}
+
+fn is_pretool_use(input: &Value) -> bool {
+    input.get("hook_event_name").and_then(Value::as_str) == Some("PreToolUse")
 }
 
 pub(super) fn extract_command(input: &Value) -> Option<String> {
@@ -67,8 +122,9 @@ pub(super) fn split_env_prefix(command: &str) -> (String, String) {
 }
 
 /// True when a previous `lade hook` already rewrote this into inject.
-/// `current_exe` is usually an absolute path, so `starts_with("lade inject")`
-/// is not enough for a user hook plus a project hook.
+/// The rewrite may be `lade` or an absolute path, so `starts_with("lade inject")`
+/// is not enough for a user hook plus a project hook. `--pretool` is the
+/// alias form (`lade --pretool '…'`).
 pub(super) fn is_already_injected(command: &str) -> bool {
     let (_, command) = split_env_prefix(command);
     let mut parts = command.split_whitespace();
@@ -79,5 +135,25 @@ pub(super) fn is_already_injected(command: &str) -> bool {
         .file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| matches!(name, "lade" | "lade.exe"));
-    is_lade && parts.any(|part| part == "inject")
+    is_lade && parts.any(|part| part == "inject" || part == "--pretool" || part == "--via=pretool")
+}
+
+/// True when the rewrite already carries pretool: `--pretool`, older
+/// `--via=pretool`, or a `LADE_VIA=pretool` env prefix.
+pub(super) fn has_pretool_stamp(env_prefix: &str, command: &str) -> bool {
+    let stamp = format!(
+        "{}={}",
+        crate::shell::LADE_VIA,
+        crate::shell::LADE_VIA_PRETOOL
+    );
+    if env_prefix.split_whitespace().any(|part| part == stamp) {
+        return true;
+    }
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    parts
+        .iter()
+        .any(|part| *part == "--pretool" || *part == "--via=pretool")
+        || parts
+            .windows(2)
+            .any(|pair| pair[0] == "--via" && pair[1] == crate::shell::LADE_VIA_PRETOOL)
 }

--- a/src/pretool/response.rs
+++ b/src/pretool/response.rs
@@ -1,8 +1,9 @@
 use super::platform::Platform;
 use serde_json::{Value, json};
 
-/// Wrap Claude Code's required `hookSpecificOutput` envelope around `fields`.
-fn claude(fields: Value) -> String {
+/// Wrap the Claude-compatible `hookSpecificOutput` envelope around `fields`.
+/// Codex, Pi, and OpenCode use this same PreToolUse rewrite contract.
+fn hook_specific(fields: Value) -> String {
     let mut out = json!({ "hookEventName": "PreToolUse" });
     if let (Some(obj), Some(extra)) = (out.as_object_mut(), fields.as_object()) {
         obj.extend(extra.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -10,26 +11,33 @@ fn claude(fields: Value) -> String {
     json!({ "hookSpecificOutput": out }).to_string()
 }
 
+fn uses_claude_envelope(platform: &Platform) -> bool {
+    matches!(
+        platform,
+        Platform::ClaudeCode | Platform::Codex | Platform::Pi | Platform::OpenCode
+    )
+}
+
 pub(super) fn format_allow(platform: &Platform) -> String {
-    match platform {
-        Platform::Cursor => json!({"permission": "allow"}).to_string(),
-        Platform::ClaudeCode => String::new(), // exit 0 with no output
+    if uses_claude_envelope(platform) {
+        return String::new();
     }
+    json!({"permission": "allow"}).to_string()
 }
 
 pub(super) fn format_modify(platform: &Platform, tool_input: &Value, new_command: &str) -> String {
     let mut updated = tool_input.clone();
     updated["command"] = json!(new_command);
 
-    match platform {
-        Platform::Cursor => json!({
-            "permission": "allow",
-            "updated_input": updated
-        })
-        .to_string(),
-        Platform::ClaudeCode => claude(json!({
+    if uses_claude_envelope(platform) {
+        return hook_specific(json!({
             "permissionDecision": "allow",
             "updatedInput": updated
-        })),
+        }));
     }
+    json!({
+        "permission": "allow",
+        "updated_input": updated
+    })
+    .to_string()
 }

--- a/src/pretool/tests.rs
+++ b/src/pretool/tests.rs
@@ -1,7 +1,20 @@
 use super::handle;
 use super::platform::{Platform, detect_platform};
 use crate::config::{Audience, Config, LadeFile};
+use serde_json::json;
 use tempfile::{TempDir, tempdir};
+
+const AGENT_ENV: [(&str, Option<&str>); 9] = [
+    ("CURSOR_VERSION", None),
+    ("CLAUDE_PROJECT_DIR", None),
+    ("CODEX_THREAD_ID", None),
+    ("CODEX_SANDBOX", None),
+    ("CODEX_HOME", None),
+    ("PI_HOME", None),
+    ("PI_CODING_AGENT", None),
+    ("OPENCODE", None),
+    ("OPENCODE_DIR", None),
+];
 
 fn test_config(pattern: &str) -> (Config, TempDir) {
     let dir = tempdir().unwrap();
@@ -26,17 +39,28 @@ fn test_config_with_disclaimer(pattern: &str, disclaimer: &str) -> (Config, Temp
     (LadeFile::build(dir.path().to_path_buf()).unwrap(), dir)
 }
 
-#[test]
-fn test_detect_cursor() {
+fn with_cursor_env<F: FnOnce()>(f: F) {
     temp_env::with_vars(
         [
             ("CURSOR_VERSION", Some("1.0")),
             ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", None),
+            ("CODEX_SANDBOX", None),
+            ("CODEX_HOME", None),
+            ("PI_HOME", None),
+            ("PI_CODING_AGENT", None),
+            ("OPENCODE", None),
+            ("OPENCODE_DIR", None),
         ],
-        || {
-            assert_eq!(detect_platform().unwrap(), Platform::Cursor);
-        },
+        f,
     );
+}
+
+#[test]
+fn test_detect_cursor() {
+    with_cursor_env(|| {
+        assert_eq!(detect_platform(&json!({})).unwrap(), Platform::Cursor);
+    });
 }
 
 #[test]
@@ -45,29 +69,77 @@ fn test_detect_claude() {
         [
             ("CURSOR_VERSION", None),
             ("CLAUDE_PROJECT_DIR", Some("/tmp")),
+            ("CODEX_THREAD_ID", None),
+            ("CODEX_SANDBOX", None),
+            ("CODEX_HOME", None),
+            ("PI_HOME", None),
+            ("PI_CODING_AGENT", None),
+            ("OPENCODE", None),
+            ("OPENCODE_DIR", None),
         ],
         || {
-            assert_eq!(detect_platform().unwrap(), Platform::ClaudeCode);
+            assert_eq!(detect_platform(&json!({})).unwrap(), Platform::ClaudeCode);
         },
     );
+}
+
+#[test]
+fn test_detect_codex_env() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", None),
+            ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", Some("thr_1")),
+            ("CODEX_SANDBOX", None),
+            ("CODEX_HOME", None),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
+        ],
+        || {
+            assert_eq!(detect_platform(&json!({})).unwrap(), Platform::Codex);
+        },
+    );
+}
+
+#[test]
+fn test_detect_pi_env() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", None),
+            ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", None),
+            ("CODEX_HOME", None),
+            ("PI_HOME", Some("/tmp/pi")),
+            ("OPENCODE", None),
+        ],
+        || {
+            assert_eq!(detect_platform(&json!({})).unwrap(), Platform::Pi);
+        },
+    );
+}
+
+#[test]
+fn test_detect_opencode_payload() {
+    temp_env::with_vars(AGENT_ENV, || {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "hook_source": "opencode-plugin",
+            "tool_input": {"command": "echo hello"}
+        });
+        assert_eq!(detect_platform(&input).unwrap(), Platform::OpenCode);
+    });
 }
 
 #[test]
 fn test_detect_unknown_fails() {
-    temp_env::with_vars(
-        [
-            ("CURSOR_VERSION", None::<&str>),
-            ("CLAUDE_PROJECT_DIR", None),
-        ],
-        || {
-            assert!(detect_platform().is_err());
-        },
-    );
+    temp_env::with_vars(AGENT_ENV, || {
+        assert!(detect_platform(&json!({})).is_err());
+    });
 }
 
 #[test]
 fn test_no_command_allows() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let (config, _dir) = test_config("echo");
         let result = handle(&config, "{}", Audience::Agent).unwrap();
         assert!(result.contains("allow"));
@@ -76,7 +148,7 @@ fn test_no_command_allows() {
 
 #[test]
 fn test_no_match_allows() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let (config, _dir) = test_config("^terraform");
         let input = r#"{"tool_input": {"command": "echo hello"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
@@ -86,13 +158,13 @@ fn test_no_match_allows() {
 
 #[test]
 fn test_match_wraps_cursor() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let (config, _dir) = test_config("^echo");
         let input = r#"{"tool_input": {"command": "echo hello"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
-        assert!(result.contains("inject 'echo hello'"));
+        assert!(result.contains("--pretool 'echo hello'"));
         assert!(result.contains("updated_input"));
-        assert!(result.contains("LADE_VIA=pretool "));
+        assert!(!result.contains("LADE_VIA=pretool "));
     });
 }
 
@@ -102,15 +174,78 @@ fn test_match_wraps_claude() {
         [
             ("CURSOR_VERSION", None),
             ("CLAUDE_PROJECT_DIR", Some("/tmp")),
+            ("CODEX_THREAD_ID", None),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
         ],
         || {
             let (config, _dir) = test_config("^echo");
             let input = r#"{"tool_input": {"command": "echo hello"}}"#;
             let result = handle(&config, input, Audience::Agent).unwrap();
-            assert!(result.contains("inject 'echo hello'"));
+            assert!(result.contains("--pretool 'echo hello'"));
             assert!(result.contains("hookSpecificOutput"));
             assert!(result.contains("updatedInput"));
-            assert!(result.contains("LADE_VIA=pretool "));
+            assert!(!result.contains("LADE_VIA=pretool "));
+        },
+    );
+}
+
+#[test]
+fn test_match_wraps_codex() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", None),
+            ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", Some("thr_1")),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
+        ],
+        || {
+            let (config, _dir) = test_config("^echo");
+            let input = r#"{"tool_name":"Bash","tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse"}"#;
+            let result = handle(&config, input, Audience::Agent).unwrap();
+            assert!(result.contains("--pretool 'echo hello'"));
+            assert!(result.contains("updatedInput"));
+            assert!(!result.contains("LADE_VIA=pretool "));
+        },
+    );
+}
+
+#[test]
+fn test_match_wraps_pi() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", None),
+            ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", None),
+            ("PI_HOME", Some("/tmp/pi")),
+            ("OPENCODE", None),
+        ],
+        || {
+            let (config, _dir) = test_config("^echo");
+            let input = r#"{"tool_name":"bash","tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse"}"#;
+            let result = handle(&config, input, Audience::Agent).unwrap();
+            assert!(result.contains("--pretool 'echo hello'"));
+            assert!(result.contains("updatedInput"));
+        },
+    );
+}
+
+#[test]
+fn test_claude_no_match_allows_silently() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", None),
+            ("CLAUDE_PROJECT_DIR", Some("/tmp")),
+            ("CODEX_THREAD_ID", None),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
+        ],
+        || {
+            let (config, _dir) = test_config("^terraform");
+            let input = r#"{"tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse"}"#;
+            let result = handle(&config, input, Audience::Agent).unwrap();
+            assert_eq!(result, "");
         },
     );
 }
@@ -124,6 +259,11 @@ fn test_disclaimer_command_is_rewritten() {
         [
             ("CURSOR_VERSION", Some("1.0")),
             ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", None),
+            ("CODEX_SANDBOX", None),
+            ("CODEX_HOME", None),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
             ("LADE_APPROVE", None),
             ("LADE_DISCLAIMER_APPROVED", None),
         ],
@@ -131,9 +271,9 @@ fn test_disclaimer_command_is_rewritten() {
             let (config, _dir) = test_config_with_disclaimer("^echo", "Danger ahead.");
             let input = r#"{"tool_input": {"command": "echo hello"}}"#;
             let result = handle(&config, input, Audience::Agent).unwrap();
-            assert!(result.contains("inject 'echo hello'"));
+            assert!(result.contains("--pretool 'echo hello'"));
             assert!(result.contains("updated_input"));
-            assert!(result.contains("LADE_VIA=pretool "));
+            assert!(!result.contains("LADE_VIA=pretool "));
             assert!(!result.contains("deny"));
         },
     );
@@ -141,45 +281,49 @@ fn test_disclaimer_command_is_rewritten() {
 
 #[test]
 fn test_env_prefix_kept_before_inject() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let (config, _dir) = test_config("^echo");
         let input = r#"{"tool_input": {"command": "LADE_APPROVE=ab12c echo hello"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
         assert!(result.contains("LADE_APPROVE=ab12c "));
-        assert!(result.contains("LADE_VIA=pretool "));
-        assert!(result.contains("inject 'echo hello'"));
+        assert!(result.contains("--pretool 'echo hello'"));
+        assert!(!result.contains("LADE_VIA=pretool "));
     });
 }
 
 #[test]
-fn test_already_wrapped_skips() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+fn test_already_wrapped_stamps_via() {
+    with_cursor_env(|| {
         let (config, _dir) = test_config(".*");
         let input = r#"{"tool_input": {"command": "lade inject 'echo'"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
-        assert!(result.contains("allow"));
-        assert!(!result.contains("updated_input"));
+        assert!(result.contains("updated_input"));
+        assert!(result.contains("lade --pretool inject 'echo'"));
+        assert!(!result.contains("LADE_VIA=pretool "));
     });
 }
 
 #[test]
-fn test_already_wrapped_absolute_path_skips() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+fn test_already_wrapped_absolute_path_stamps_via() {
+    with_cursor_env(|| {
         let (config, _dir) = test_config(".*");
         let input = r#"{"tool_input": {"command": "/usr/local/bin/lade inject 'echo hello'"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
-        assert!(result.contains("allow"));
-        assert!(!result.contains("updated_input"));
+        assert!(result.contains("updated_input"));
+        assert!(result.contains("/usr/local/bin/lade --pretool inject 'echo hello'"));
+        assert!(!result.contains("LADE_VIA=pretool "));
     });
 }
 
 #[test]
 fn test_already_injected_detects_lade_binaries() {
+    assert!(super::platform::is_already_injected("lade --pretool echo"));
     assert!(super::platform::is_already_injected("lade inject 'echo'"));
     assert!(super::platform::is_already_injected(
         "/usr/local/bin/lade inject -- echo"
     ));
     assert!(!super::platform::is_already_injected("lade hook"));
+    assert!(!super::platform::is_already_injected("lade status"));
     assert!(!super::platform::is_already_injected("echo lade inject"));
     assert!(super::platform::is_already_injected(
         "/usr/bin/lade.exe inject echo"
@@ -190,20 +334,22 @@ fn test_already_injected_detects_lade_binaries() {
 }
 
 #[test]
-fn test_env_prefix_already_injected_skips() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+fn test_env_prefix_already_injected_stamps_via() {
+    with_cursor_env(|| {
         let (config, _dir) = test_config(".*");
         let input =
             r#"{"tool_input": {"command": "LADE_APPROVE=ab12c /usr/bin/lade inject 'echo'"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
-        assert!(result.contains("allow"));
-        assert!(!result.contains("updated_input"));
+        assert!(result.contains("updated_input"));
+        assert!(result.contains("LADE_APPROVE=ab12c "));
+        assert!(result.contains("/usr/bin/lade --pretool inject 'echo'"));
+        assert!(!result.contains("LADE_VIA=pretool "));
     });
 }
 
 #[test]
 fn test_hook_stamp_already_injected_skips() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let (config, _dir) = test_config(".*");
         let input =
             r#"{"tool_input": {"command": "LADE_VIA=pretool /usr/bin/lade inject 'echo'"}}"#;
@@ -214,8 +360,41 @@ fn test_hook_stamp_already_injected_skips() {
 }
 
 #[test]
+fn test_pretool_flag_already_injected_skips() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config(".*");
+        let input = r#"{"tool_input": {"command": "/usr/bin/lade --pretool 'echo'"}}"#;
+        let result = handle(&config, input, Audience::Agent).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("updated_input"));
+    });
+}
+
+#[test]
+fn test_via_flag_already_injected_skips() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config(".*");
+        let input = r#"{"tool_input": {"command": "/usr/bin/lade --via=pretool inject 'echo'"}}"#;
+        let result = handle(&config, input, Audience::Agent).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("updated_input"));
+    });
+}
+
+#[test]
+fn test_via_flag_after_inject_already_injected_skips() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config(".*");
+        let input = r#"{"tool_input": {"command": "/usr/bin/lade inject --via=pretool 'echo'"}}"#;
+        let result = handle(&config, input, Audience::Agent).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("updated_input"));
+    });
+}
+
+#[test]
 fn test_agent_when_wraps() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("lade.yml"),
@@ -225,14 +404,13 @@ fn test_agent_when_wraps() {
         let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
         let input = r#"{"tool_input": {"command": "echo hello"}}"#;
         let result = handle(&config, input, Audience::Agent).unwrap();
-        assert!(result.contains("inject 'echo hello'"));
-        assert!(result.contains("LADE_VIA=pretool "));
+        assert!(result.contains("--pretool 'echo hello'"));
     });
 }
 
 #[test]
 fn test_human_when_does_not_wrap() {
-    temp_env::with_var("CURSOR_VERSION", Some("1.0"), || {
+    with_cursor_env(|| {
         let dir = tempdir().unwrap();
         std::fs::write(
             dir.path().join("lade.yml"),
@@ -245,4 +423,60 @@ fn test_human_when_does_not_wrap() {
         assert!(result.contains("allow"));
         assert!(!result.contains("updated_input"));
     });
+}
+
+#[test]
+fn test_cursor_version_does_not_override_codex_envelope() {
+    temp_env::with_vars(
+        [
+            ("CURSOR_VERSION", Some("1.0")),
+            ("CLAUDE_PROJECT_DIR", None),
+            ("CODEX_THREAD_ID", Some("thr_1")),
+            ("PI_HOME", None),
+            ("OPENCODE", None),
+        ],
+        || {
+            let (config, _dir) = test_config("^echo");
+            let input = r#"{"tool_name":"Bash","tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse","turn_id":"t1"}"#;
+            let result = handle(&config, input, Audience::Agent).unwrap();
+            assert!(result.contains("updatedInput"));
+            assert!(!result.contains("updated_input"));
+            assert!(result.contains("--pretool 'echo hello'"));
+        },
+    );
+}
+
+#[test]
+fn test_pretool_use_event_keeps_claude_envelope_with_cursor_version() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config("^echo");
+        let input = r#"{"tool_name":"Bash","tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse"}"#;
+        let result = handle(&config, input, Audience::Agent).unwrap();
+        assert!(result.contains("updatedInput"));
+        assert!(!result.contains("updated_input"));
+    });
+}
+
+#[test]
+fn invoked_lade_bin_from_path_stays_bare() {
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    let exe = PathBuf::from("/opt/lade");
+    assert_eq!(
+        super::invoked_lade_bin_from(Some(OsString::from("lade")), Some(exe.clone())),
+        "lade"
+    );
+    assert_eq!(
+        super::invoked_lade_bin_from(Some(OsString::from("lade.exe")), Some(exe.clone())),
+        "lade.exe"
+    );
+    assert_eq!(
+        super::invoked_lade_bin_from(Some(OsString::from("/opt/custom/lade")), Some(exe.clone())),
+        "/opt/lade"
+    );
+    assert_eq!(
+        super::invoked_lade_bin_from(Some(OsString::from("./target/debug/lade")), Some(exe)),
+        "/opt/lade"
+    );
 }

--- a/src/shell/preexec.rs
+++ b/src/shell/preexec.rs
@@ -76,19 +76,16 @@ impl Shell {
 }
 
 fn configure_auto_launch(shell: &Shell, install: bool) -> Result<PathBuf> {
-    let curr_exe = std::env::current_exe()?;
+    let bin = crate::pretool::invoked_lade_bin();
 
     let (command, config_file) = match shell {
         Shell::Bash => (
-            format!("source <(echo \"$({} on)\")", curr_exe.display()),
+            format!("source <(echo \"$({bin} on)\")"),
             profile_config_file(shell),
         ),
-        Shell::Zsh => (
-            format!("eval \"$({} on)\"", curr_exe.display()),
-            profile_config_file(shell),
-        ),
+        Shell::Zsh => (format!("eval \"$({bin} on)\""), profile_config_file(shell)),
         Shell::Fish => (
-            format!("source ({} on | psub)", curr_exe.display()),
+            format!("source ({bin} on | psub)"),
             profile_config_file(shell),
         ),
         _ => bail!("Unsupported behavior on shell {}", shell.bin()),

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use chrono::{DateTime, Local, Utc};
 use serde::Serialize;
 
 use crate::args::StatusCommand;
@@ -17,6 +18,7 @@ struct VersionInfo {
     latest: Option<String>,
     update_available: bool,
     check_error: Option<String>,
+    last_check: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize)]
@@ -96,18 +98,21 @@ async fn gather(opts: &StatusCommand) -> Result<StatusReport> {
             latest: status.latest,
             update_available: status.update_available,
             check_error: None,
+            last_check: status.last_check,
         },
         Ok(Err(e)) => VersionInfo {
             current,
             latest: None,
             update_available: false,
             check_error: Some(e.to_string()),
+            last_check: None,
         },
         Err(_) => VersionInfo {
             current,
             latest: None,
             update_available: false,
             check_error: Some("update check timed out".to_string()),
+            last_check: None,
         },
     };
 
@@ -206,7 +211,10 @@ fn print_human(report: &StatusReport) {
                     println!("  latest: {latest} (update available. run `lade upgrade`)")
                 }
                 (Some(latest), false) => println!("  latest: {latest} (up to date)"),
-                (None, _) => println!("  latest: (not checked recently)"),
+                (None, _) => match v.last_check {
+                    Some(at) => println!("  latest: ({})", format_tried_at(at, Local::now())),
+                    None => println!("  latest: (not checked yet)"),
+                },
             }
         }
     }
@@ -233,6 +241,12 @@ fn print_human(report: &StatusReport) {
     print_pretool_line("Cursor project", &report.hooks.pretool.cursor.project);
     print_pretool_line("Claude Code global", &report.hooks.pretool.claude.global);
     print_pretool_line("Claude Code project", &report.hooks.pretool.claude.project);
+    print_pretool_line("Codex global", &report.hooks.pretool.codex.global);
+    print_pretool_line("Codex project", &report.hooks.pretool.codex.project);
+    print_pretool_line("Pi global", &report.hooks.pretool.pi.global);
+    print_pretool_line("Pi project", &report.hooks.pretool.pi.project);
+    print_pretool_line("OpenCode global", &report.hooks.pretool.opencode.global);
+    print_pretool_line("OpenCode project", &report.hooks.pretool.opencode.project);
 
     let pc = &report.project_config;
     if let Some(err) = &pc.error {
@@ -269,4 +283,70 @@ fn display_path(path: &Path) -> String {
         return format!("~/{}", stripped.display());
     }
     path.display().to_string()
+}
+
+fn format_tried_at(checked_at: DateTime<Utc>, now: DateTime<Local>) -> String {
+    let local = checked_at.with_timezone(&Local);
+    let today = now.date_naive();
+    let day = local.date_naive();
+    let time = local.format("%H:%M");
+    if day == today {
+        format!("tried today at {time}")
+    } else if day.checked_add_days(chrono::Days::new(1)) == Some(today) {
+        format!("tried yesterday at {time}")
+    } else {
+        format!("tried {} at {time}", local.format("%d %b %Y"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveTime;
+
+    fn local_at(now: DateTime<Local>, days_ago: u64, hour: u32, minute: u32) -> DateTime<Local> {
+        let date = now
+            .date_naive()
+            .checked_sub_days(chrono::Days::new(days_ago))
+            .unwrap();
+        let time = NaiveTime::from_hms_opt(hour, minute, 0).unwrap();
+        date.and_time(time)
+            .and_local_timezone(Local)
+            .earliest()
+            .unwrap()
+    }
+
+    #[test]
+    fn tried_at_today_includes_local_time() {
+        let now = Local::now();
+        let checked = local_at(now, 0, 14, 25);
+        assert_eq!(
+            format_tried_at(checked.with_timezone(&Utc), now),
+            format!("tried today at {}", checked.format("%H:%M"))
+        );
+    }
+
+    #[test]
+    fn tried_at_yesterday_includes_local_time() {
+        let now = Local::now();
+        let checked = local_at(now, 1, 9, 5);
+        assert_eq!(
+            format_tried_at(checked.with_timezone(&Utc), now),
+            format!("tried yesterday at {}", checked.format("%H:%M"))
+        );
+    }
+
+    #[test]
+    fn tried_at_older_uses_calendar_date() {
+        let now = Local::now();
+        let checked = local_at(now, 3, 18, 0);
+        assert_eq!(
+            format_tried_at(checked.with_timezone(&Utc), now),
+            format!(
+                "tried {} at {}",
+                checked.format("%d %b %Y"),
+                checked.format("%H:%M")
+            )
+        );
+    }
 }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -20,6 +20,7 @@ pub struct VersionStatus {
     pub current: String,
     pub latest: Option<String>,
     pub update_available: bool,
+    pub last_check: Option<DateTime<Utc>>,
 }
 
 pub fn check_is_due(update_check: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
@@ -67,24 +68,30 @@ pub async fn fetch_version_status() -> Result<VersionStatus> {
     let local_config = GlobalConfig::load().await?;
 
     if !check_is_due(local_config.update_check, Utc::now()) {
+        let latest = local_config.latest_version;
+        let available = update_available(&latest, &current);
         return Ok(VersionStatus {
             current,
-            latest: None,
-            update_available: false,
+            latest,
+            update_available: available,
+            last_check: local_config.update_check,
         });
     }
 
     // Stamp first so a slow or failing GitHub call is not retried on every
     // subsequent `lade set` / `lade inject` in this 24h window.
-    GlobalConfig::update(|c| c.update_check = Some(Utc::now())).await?;
+    let now = Utc::now();
+    GlobalConfig::update(|c| c.update_check = Some(now)).await?;
 
     let latest = tokio::task::spawn_blocking(fetch_latest_tag).await??;
+    GlobalConfig::update(|c| c.latest_version = Some(latest.clone())).await?;
     let available = update_available(&Some(latest.clone()), &current);
 
     Ok(VersionStatus {
         current,
         latest: Some(latest),
         update_available: available,
+        last_check: Some(now),
     })
 }
 
@@ -191,6 +198,32 @@ mod tests {
                     let status = fetch_version_status().await.unwrap();
                     assert_eq!(status.latest, None);
                     assert!(!status.update_available);
+                    assert!(status.last_check.is_some());
+                });
+        });
+    }
+
+    #[test]
+    fn fetch_returns_cached_latest_when_not_due() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"update_check":"2099-01-01T00:00:00Z","latest_version":"0.18.0","user":null,"cli_check":{}}"#,
+        )
+        .unwrap();
+        temp_env::with_vars([("LADE_CONFIG_PATH", Some(path.to_str().unwrap()))], || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let status = fetch_version_status().await.unwrap();
+                    assert_eq!(status.latest.as_deref(), Some("0.18.0"));
+                    assert_eq!(
+                        status.update_available,
+                        update_available(&Some("0.18.0".to_string()), cargo_crate_version!())
+                    );
                 });
         });
     }

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -380,22 +380,60 @@ fn test_inject_agent_when_requires_pretool_stamp() {
         .stdout(predicates::str::contains("agentsecret").not());
     common::lade(home.path())
         .current_dir(dir.path())
+        .args(["--pretool", "inject", "--no-mask", "echo", "$SECRET"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("agentsecret"));
+    common::lade(home.path())
+        .current_dir(dir.path())
         .env("LADE_VIA", "pretool")
         .args(["inject", "--no-mask", "echo", "$SECRET"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("agentsecret"));
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .env("LADE_VIA", "preexec")
+        .args(["--pretool", "inject", "--no-mask", "echo", "$SECRET"])
         .assert()
         .success()
         .stdout(predicates::str::contains("agentsecret"));
 }
 
 #[test]
-fn test_inject_strips_via_stamp_from_child() {
+fn test_inject_pretool_sets_via_on_child() {
     let dir = tempdir().unwrap();
     let home = tempdir().unwrap();
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["--pretool", "inject", "--no-mask", "echo", "via=$LADE_VIA"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("via=pretool"));
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["--pretool", "echo", "via=$LADE_VIA"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("via=pretool"));
     common::lade(home.path())
         .current_dir(dir.path())
         .env("LADE_VIA", "pretool")
         .args(["inject", "--no-mask", "echo", "via=$LADE_VIA"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("via=pretool").not());
+        .stdout(predicates::str::contains("via=pretool"));
+}
+
+#[test]
+fn test_inject_without_stamp_strips_via_from_child() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["inject", "--no-mask", "echo", "via=$LADE_VIA"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("via=pretool").not())
+        .stdout(predicates::str::contains("via=preexec").not());
 }

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -17,7 +17,7 @@ fn test_status_reports_version_and_project() {
         .assert()
         .stdout(predicates::str::contains("lade version:"))
         .stdout(predicates::str::contains("latest:"))
-        .stdout(predicates::str::contains("not checked recently"))
+        .stdout(predicates::str::contains("tried"))
         .stdout(predicates::str::contains("project config: ok"));
 }
 
@@ -46,11 +46,20 @@ fn test_status_json_is_valid_with_expected_keys() {
     assert!(value["hooks"].get("pretool").is_some());
     assert!(value["hooks"]["pretool"].get("cursor").is_some());
     assert!(value["hooks"]["pretool"].get("claude").is_some());
+    assert!(value["hooks"]["pretool"].get("codex").is_some());
+    assert!(value["hooks"]["pretool"].get("pi").is_some());
+    assert!(value["hooks"]["pretool"].get("opencode").is_some());
     assert!(value.get("project_config").is_some());
     assert!(value.get("ok").is_some());
     assert!(value["project_config"]["error"].is_null());
     assert!(value["version"]["latest"].is_null());
     assert_eq!(value["version"]["update_available"], false);
+    assert!(
+        value["version"]["last_check"]
+            .as_str()
+            .unwrap()
+            .starts_with("2099-01-01")
+    );
 }
 
 #[test]
@@ -92,5 +101,41 @@ fn test_status_reports_project_pretool_hook() {
             .as_str()
             .unwrap()
             .ends_with(".cursor/hooks.json")
+    );
+}
+
+#[test]
+fn test_status_reports_project_codex_pretool_hook() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"mycmd\":\n  SECRET: mysecret\n",
+    )
+    .unwrap();
+    fs::create_dir_all(dir.path().join(".codex")).unwrap();
+    fs::write(
+        dir.path().join(".codex").join("hooks.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"lade hook"}]}]}}"#,
+    )
+    .unwrap();
+    let output = common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["status", "--json"])
+        .assert()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value =
+        serde_json::from_slice(&output).expect("status --json must emit valid JSON");
+    assert_eq!(
+        value["hooks"]["pretool"]["codex"]["project"]["installed"],
+        true
+    );
+    assert!(
+        value["hooks"]["pretool"]["codex"]["project"]["path"]
+            .as_str()
+            .unwrap()
+            .ends_with(".codex/hooks.json")
     );
 }


### PR DESCRIPTION
## Summary
- Add Codex, Pi, and OpenCode as Claude-compatible preTool hosts (`lade hook` / `install` / `status`).
- Stamp rewritten commands with `--pretool` so `.when: agent` still matches.
- Persist the last GitHub tag on `lade status` when the daily check succeeds.

Stacked on #bench.

## Test plan
- [ ] `cargo test --workspace --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `lade install` then `lade status` shows Codex / Pi / OpenCode hook paths
- [ ] After a successful version check, `lade status --json` keeps `latest` on the next run
