### PR TITLE
feat: keep resolved secrets when wrap shells source a profile

### DIFF
--- a/sdk/src/providers/mod.rs
+++ b/sdk/src/providers/mod.rs
@@ -189,6 +189,10 @@ pub async fn run_cli(
         .envs(extra_env.iter())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    // bash -c sources $BASH_ENV even though it does not read .bashrc.
+    if cmd[0] == "bash" {
+        c.env_remove("BASH_ENV");
+    }
     if let Some(dir) = cwd {
         c.current_dir(dir);
     }

--- a/sdk/src/providers/sh.rs
+++ b/sdk/src/providers/sh.rs
@@ -25,6 +25,14 @@ impl Shell {
     }
 }
 
+fn invocation<'a>(bin: &'a str, cmd: &'a str) -> Vec<&'a str> {
+    match bin {
+        "fish" => vec![bin, "--no-config", "-c", cmd],
+        "zsh" => vec![bin, "-f", "-c", cmd],
+        _ => vec![bin, "-c", cmd],
+    }
+}
+
 #[async_trait]
 impl Provider for Shell {
     fn add(&mut self, value: String) -> Result<()> {
@@ -75,7 +83,13 @@ impl Provider for Shell {
             async move {
                 let output = tokio::time::timeout(
                     Duration::from_secs(30),
-                    run_cli(&[bin, "-c", &cmd_str], &extra_env, name, install_url, None),
+                    run_cli(
+                        &invocation(bin, &cmd_str),
+                        &extra_env,
+                        name,
+                        install_url,
+                        None,
+                    ),
                 )
                 .await
                 .map_err(|_| {
@@ -109,6 +123,20 @@ mod tests {
     }
 
     #[test]
+    fn test_invocation_skips_startup_files() {
+        assert_eq!(
+            invocation("fish", "echo hi"),
+            vec!["fish", "--no-config", "-c", "echo hi"]
+        );
+        assert_eq!(invocation("bash", "echo hi"), vec!["bash", "-c", "echo hi"]);
+        assert_eq!(
+            invocation("zsh", "echo hi"),
+            vec!["zsh", "-f", "-c", "echo hi"]
+        );
+        assert_eq!(invocation("sh", "echo hi"), vec!["sh", "-c", "echo hi"]);
+    }
+
+    #[test]
     fn test_add_routing() {
         let mut p = Shell::new("sh", "sh", "url");
         assert!(p.add("sh://echo hi".to_string()).is_ok());
@@ -130,6 +158,33 @@ mod tests {
         assert_eq!(
             result.get("sh://echo \"hello world\"").unwrap(),
             "hello world"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_resolve_fish_ignores_config_overwrite() {
+        let home = tempdir().unwrap();
+        let fish_dir = home.path().join(".config/fish");
+        std::fs::create_dir_all(&fish_dir).unwrap();
+        std::fs::write(
+            fish_dir.join("config.fish"),
+            "set -x TOKEN from_fish_profile\n",
+        )
+        .unwrap();
+        let mut p = Shell::new("fish", "fish", "url");
+        p.add("fish://printf %s \"$TOKEN\"".to_string()).unwrap();
+        let extra = HashMap::from([
+            ("HOME".to_string(), home.path().display().to_string()),
+            ("TOKEN".to_string(), "from_binding".to_string()),
+        ]);
+        let result = p
+            .resolve(Path::new("."), &extra, &Warnings::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            result.get("fish://printf %s \"$TOKEN\"").unwrap(),
+            "from_binding"
         );
     }
 

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -1,4 +1,5 @@
 use crate::redact::Redactor;
+use crate::shell::Shell;
 use anyhow::Result;
 use std::{collections::HashMap, path::Path, sync::Arc};
 
@@ -26,7 +27,7 @@ fn select_mode(has_redactor: bool, stdin_tty: bool, stdout_tty: bool) -> Mode {
 
 pub fn run(
     ctx: &crate::context::InvocationContext,
-    shell: &str,
+    shell: &Shell,
     command: &str,
     mut env: HashMap<String, String>,
     cwd: &Path,
@@ -62,12 +63,18 @@ pub fn run(
     }
 }
 
-fn run_plain(shell: &str, command: &str, env: HashMap<String, String>, cwd: &Path) -> Result<i32> {
-    let status = std::process::Command::new(shell)
-        .args(["-c", command])
+fn run_plain(
+    shell: &Shell,
+    command: &str,
+    env: HashMap<String, String>,
+    cwd: &Path,
+) -> Result<i32> {
+    let status = shell
+        .prepare_command(command)
         .current_dir(cwd)
         .envs(std::env::vars())
         .env_remove(crate::shell::LADE_VIA)
+        .env_remove("BASH_ENV")
         .envs(env)
         .status()?;
     Ok(status.code().unwrap_or(1))

--- a/src/exec/piped.rs
+++ b/src/exec/piped.rs
@@ -1,14 +1,10 @@
 use crate::redact::Redactor;
+use crate::shell::Shell;
 use anyhow::Result;
-use std::{
-    collections::HashMap,
-    path::Path,
-    process::{Command, Stdio},
-    sync::Arc,
-};
+use std::{collections::HashMap, path::Path, process::Stdio, sync::Arc};
 
 pub fn run(
-    shell: &str,
+    shell: &Shell,
     command: &str,
     env: HashMap<String, String>,
     cwd: &Path,
@@ -18,11 +14,12 @@ pub fn run(
     // stdin forwarded by a helper thread risks SIGPIPE (SIG_DFL at startup
     // kills the process) when the child exits before consuming forwarded
     // bytes, which is observable on Linux CI.
-    let mut child = Command::new(shell)
-        .args(["-c", command])
+    let mut child = shell
+        .prepare_command(command)
         .current_dir(cwd)
         .envs(std::env::vars())
         .env_remove(crate::shell::LADE_VIA)
+        .env_remove("BASH_ENV")
         .envs(env)
         .stdin(Stdio::inherit())
         .stdout(Stdio::piped())

--- a/src/exec/pty.rs
+++ b/src/exec/pty.rs
@@ -1,18 +1,19 @@
 #![cfg(unix)]
 
 use crate::redact::Redactor;
+use crate::shell::Shell;
 use anyhow::Result;
 use std::{
     fs::File,
     os::fd::{AsRawFd, OwnedFd},
     path::Path,
-    process::{Command, Stdio},
+    process::Stdio,
     sync::Arc,
 };
 
 #[cfg(unix)]
 pub fn run(
-    shell: &str,
+    shell: &Shell,
     command: &str,
     env: std::collections::HashMap<String, String>,
     cwd: &Path,
@@ -33,11 +34,12 @@ pub fn run(
     // manage their own termios for reading a line.
     let _raw_guard = RawStdinGuard::enter();
 
-    let mut child = Command::new(shell)
-        .args(["-c", command])
+    let mut child = shell
+        .prepare_command(command)
         .current_dir(cwd)
         .envs(std::env::vars())
         .env_remove(crate::shell::LADE_VIA)
+        .env_remove("BASH_ENV")
         .envs(env)
         .stdin(Stdio::inherit())
         .stdout(Stdio::from(slave_out))

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -96,7 +96,7 @@ pub async fn run_inject(
     } else {
         None
     };
-    let code = exec::run(ctx, shell.bin(), &command, env, current_dir, redactor);
+    let code = exec::run(ctx, shell, &command, env, current_dir, redactor);
     let code = match code {
         Ok(code) => {
             remove_files(&mut files.keys())?;
@@ -127,14 +127,7 @@ fn run_command_without_providers(
     } else {
         None
     };
-    let code = exec::run(
-        ctx,
-        shell.bin(),
-        command,
-        HashMap::new(),
-        current_dir,
-        redactor,
-    )?;
+    let code = exec::run(ctx, shell, command, HashMap::new(), current_dir, redactor)?;
     Ok((code != 0).then_some(code))
 }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -95,6 +95,40 @@ impl Shell {
         }
     }
 
+    /// Argv after the binary for a non-interactive `-c` that must not source
+    /// user startup files. `fish -c` reads `config.fish` and `zsh -c` reads
+    /// `.zshenv`; either can overwrite resolved secrets after process env is
+    /// applied. `bash -c` does not read `.bashrc` / `.bash_profile`; its
+    /// overwrite vector is `$BASH_ENV`, cleared on the child `Command`.
+    /// `--norc --noprofile` are omitted: they do not skip `BASH_ENV`, and
+    /// `bash -c` does not read `.bashrc` or login profiles anyway. Preexec
+    /// does not use this: it evals `set()` in the already-running
+    /// interactive shell.
+    pub fn noninteractive_args<'a>(&self, command: &'a str) -> Vec<&'a str> {
+        match self {
+            Shell::Fish => vec!["--no-config", "-c", command],
+            Shell::Zsh => vec!["-f", "-c", command],
+            Shell::Bash | Shell::Sh => vec!["-c", command],
+        }
+    }
+
+    pub fn prepare_command(&self, command: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new(self.bin());
+        cmd.args(self.noninteractive_args(command));
+        cmd
+    }
+
+    /// Startup file `inject` skips when present. `None` for bash/sh: those
+    /// `-c` invocations do not read a user file unless `$BASH_ENV` is set.
+    pub fn wrap_startup_file(&self) -> Option<PathBuf> {
+        let home = directories::UserDirs::new()?.home_dir().to_path_buf();
+        match self {
+            Shell::Fish => Some(home.join(".config/fish/config.fish")),
+            Shell::Zsh => Some(home.join(".zshenv")),
+            Shell::Bash | Shell::Sh => None,
+        }
+    }
+
     pub fn detect() -> Result<Shell> {
         if let Ok(shell_env) = std::env::var("LADE_SHELL") {
             let path = std::path::Path::new(&shell_env);
@@ -299,6 +333,39 @@ mod tests {
         let env = HashMap::from([("KEY".to_string(), "val'ue".to_string())]);
         let result = Shell::Bash.set(env);
         assert_eq!(result, "export KEY='val'\\''ue'");
+    }
+
+    #[test]
+    fn wrap_startup_file_is_shell_specific() {
+        assert!(
+            Shell::Fish
+                .wrap_startup_file()
+                .unwrap()
+                .ends_with(".config/fish/config.fish")
+        );
+        assert!(Shell::Zsh.wrap_startup_file().unwrap().ends_with(".zshenv"));
+        assert!(Shell::Bash.wrap_startup_file().is_none());
+        assert!(Shell::Sh.wrap_startup_file().is_none());
+    }
+
+    #[test]
+    fn noninteractive_args_skip_startup_files() {
+        assert_eq!(
+            Shell::Fish.noninteractive_args("echo hi"),
+            vec!["--no-config", "-c", "echo hi"]
+        );
+        assert_eq!(
+            Shell::Bash.noninteractive_args("echo hi"),
+            vec!["-c", "echo hi"]
+        );
+        assert_eq!(
+            Shell::Zsh.noninteractive_args("echo hi"),
+            vec!["-f", "-c", "echo hi"]
+        );
+        assert_eq!(
+            Shell::Sh.noninteractive_args("echo hi"),
+            vec!["-c", "echo hi"]
+        );
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -32,6 +32,9 @@ struct PreexecHooks {
     shell: String,
     profile: PathBuf,
     installed: bool,
+    inject_skips_startup_files: bool,
+    /// Set when inject will skip a file or `$BASH_ENV` that exists now.
+    inject_startup_skipped: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -129,6 +132,8 @@ async fn gather(opts: &StatusCommand) -> Result<StatusReport> {
             shell: shell.bin().to_string(),
             profile,
             installed,
+            inject_skips_startup_files: true,
+            inject_startup_skipped: inject_startup_skipped(&shell),
         },
         pretool: pretool::install::inspect(&cwd)?,
     };
@@ -235,6 +240,10 @@ fn print_human(report: &StatusReport) {
     } else {
         println!("  installed: no (run `lade install`)");
     }
+    match &report.hooks.preexec.inject_startup_skipped {
+        Some(name) => println!("  inject wrap: skips startup files ({name} present)"),
+        None => println!("  inject wrap: skips startup files"),
+    }
 
     println!("preTool hooks");
     print_pretool_line("Cursor global", &report.hooks.pretool.cursor.global);
@@ -266,6 +275,22 @@ fn print_human(report: &StatusReport) {
             println!("  {} {} < {} ({})", w.name, w.found, w.min, w.install_url);
         }
     }
+}
+
+fn inject_startup_skipped(shell: &shell::Shell) -> Option<String> {
+    if matches!(shell, shell::Shell::Bash) && std::env::var_os("BASH_ENV").is_some() {
+        return Some("BASH_ENV".to_string());
+    }
+    let path = shell.wrap_startup_file()?;
+    if !path.is_file() {
+        return None;
+    }
+    Some(
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("startup file")
+            .to_string(),
+    )
 }
 
 fn print_pretool_line(label: &str, location: &pretool::install::HookLocation) {

--- a/tests/inject.rs
+++ b/tests/inject.rs
@@ -437,3 +437,67 @@ fn test_inject_without_stamp_strips_via_from_child() {
         .stdout(predicates::str::contains("via=pretool").not())
         .stdout(predicates::str::contains("via=preexec").not());
 }
+
+#[cfg(unix)]
+fn write_fish_overwrite_fixture(dir: &std::path::Path, home: &std::path::Path) {
+    let fish_dir = home.join(".config/fish");
+    fs::create_dir_all(&fish_dir).unwrap();
+    fs::write(
+        fish_dir.join("config.fish"),
+        "set -x SECRET from_fish_profile\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("lade.yml"),
+        "\"echo.*\":\n  SECRET: 'sh://printf %s resolved_secret_fish42'\n",
+    )
+    .unwrap();
+}
+
+#[test]
+#[cfg(unix)]
+fn test_inject_survives_fish_profile_overwrite() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    write_fish_overwrite_fixture(dir.path(), home.path());
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .env("LADE_SHELL", "fish")
+        .env_remove("XDG_CONFIG_HOME")
+        .args(["inject", "--no-mask", "echo", "$SECRET"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("resolved_secret_fish42"))
+        .stdout(predicates::str::contains("from_fish_profile").not());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_inject_masks_secret_when_fish_profile_would_overwrite() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    write_fish_overwrite_fixture(dir.path(), home.path());
+    let out = common::lade(home.path())
+        .current_dir(dir.path())
+        .env("LADE_SHELL", "fish")
+        .env_remove("XDG_CONFIG_HOME")
+        .args(["inject", "echo", "$SECRET"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&out);
+    assert!(
+        !stdout.contains("resolved_secret_fish42"),
+        "resolved secret leaked into output: {stdout}"
+    );
+    assert!(
+        !stdout.contains("from_fish_profile"),
+        "profile value leaked; resolved secret did not reach the child: {stdout}"
+    );
+    assert!(
+        stdout.contains("${SECRET:-REDACTED}"),
+        "expected redaction token in output: {stdout}"
+    );
+}

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -319,3 +319,32 @@ fn test_set_skips_agent_when_rules() {
         .success()
         .stdout(predicates::str::contains("export SECRET").not());
 }
+
+#[test]
+fn test_set_fish_still_evals_in_the_interactive_shell() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::write(
+        dir.path().join("lade.yml"),
+        "\"mycmd\":\n  SECRET: mysecret\n",
+    )
+    .unwrap();
+    let out = common::lade(home.path())
+        .current_dir(dir.path())
+        .env("LADE_SHELL", "fish")
+        .args(["set", "mycmd"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&out);
+    assert!(
+        stdout.contains("set --global --export SECRET 'mysecret'"),
+        "preexec must keep fish set() syntax: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--no-config"),
+        "preexec must not switch the interactive shell to --no-config: {stdout}"
+    );
+}

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -18,7 +18,10 @@ fn test_status_reports_version_and_project() {
         .stdout(predicates::str::contains("lade version:"))
         .stdout(predicates::str::contains("latest:"))
         .stdout(predicates::str::contains("tried"))
-        .stdout(predicates::str::contains("project config: ok"));
+        .stdout(predicates::str::contains("project config: ok"))
+        .stdout(predicates::str::contains(
+            "inject wrap: skips startup files",
+        ));
 }
 
 #[test]
@@ -51,6 +54,10 @@ fn test_status_json_is_valid_with_expected_keys() {
     assert!(value["hooks"]["pretool"].get("opencode").is_some());
     assert!(value.get("project_config").is_some());
     assert!(value.get("ok").is_some());
+    assert_eq!(
+        value["hooks"]["preexec"]["inject_skips_startup_files"],
+        true
+    );
     assert!(value["project_config"]["error"].is_null());
     assert!(value["version"]["latest"].is_null());
     assert_eq!(value["version"]["update_available"], false);
@@ -138,4 +145,20 @@ fn test_status_reports_project_codex_pretool_hook() {
             .unwrap()
             .ends_with(".codex/hooks.json")
     );
+}
+
+#[test]
+fn test_status_names_present_fish_startup_file() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    fs::create_dir_all(home.path().join(".config/fish")).unwrap();
+    fs::write(home.path().join(".config/fish/config.fish"), "set -x X 1\n").unwrap();
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .env("LADE_SHELL", "fish")
+        .arg("status")
+        .assert()
+        .stdout(predicates::str::contains(
+            "inject wrap: skips startup files (config.fish present)",
+        ));
 }


### PR DESCRIPTION
## Summary
- `lade inject` / hook wrap fish with `--no-config` and zsh with `-f`, and clear `$BASH_ENV`, so a user profile cannot silently overwrite resolved secrets after spawn.
- `sh://` / `fish://` / `zsh://` resolvers use the same no-startup-file argv. Preexec (`lade set`) stays on the live interactive shell.
- `lade status` reports that inject skips startup files, and names `config.fish`, `.zshenv`, or `BASH_ENV` when that file or variable is present.

## Test plan
- [x] Isolated `config.fish` overwrite: `LADE_SHELL=fish lade inject --no-mask` sees the resolved `sh://` value, not `from_fish_profile`
- [x] Same fixture with default masking: stdout is `${SECRET:-REDACTED}`, neither the secret nor the profile value
- [x] `fish://` resolve with an isolated `config.fish` that overwrites a binding keeps the injected extra env
- [x] `lade set` with `LADE_SHELL=fish` still emits `set --global --export` and does not mention `--no-config`
- [x] `lade status` / `--json` show the skip-profile line and `inject_skips_startup_files`
- [x] Existing PTY tests still pass (`bash -c` wrap, no `--norc --noprofile`)
- [ ] CI native job on Ubuntu and macOS (both install fish and zsh)
