### PR TITLE
feat: restart MCP stdio before initialize and wrap child signals

### DIFF
--- a/src/child_signals.rs
+++ b/src/child_signals.rs
@@ -1,0 +1,185 @@
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+
+static CHILD_PID: AtomicI32 = AtomicI32::new(0);
+static KILL_GROUP: AtomicBool = AtomicBool::new(false);
+static STOP: AtomicBool = AtomicBool::new(false);
+static STOP_SIGNAL: AtomicI32 = AtomicI32::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalAction {
+    Ignore,
+    Forward,
+    Stop,
+}
+
+#[cfg(unix)]
+pub fn signal_action(signal: nix::sys::signal::Signal) -> SignalAction {
+    use nix::sys::signal::Signal::*;
+    match signal {
+        SIGHUP => SignalAction::Ignore,
+        SIGINT | SIGTERM | SIGQUIT => SignalAction::Stop,
+        SIGUSR1 | SIGUSR2 | SIGWINCH => SignalAction::Forward,
+        _ => SignalAction::Ignore,
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ChildWatch;
+
+impl ChildWatch {
+    pub fn new() -> Self {
+        install();
+        Self
+    }
+
+    pub fn set_pid(&self, pid: u32, group: bool) {
+        KILL_GROUP.store(group, Ordering::Release);
+        CHILD_PID.store(pid as i32, Ordering::Release);
+        // A stop signal can arrive after clear_pid and before the next
+        // set_pid. Replay it so a respawned child does not outlive the wrapper.
+        #[cfg(unix)]
+        unix::flush_pending();
+    }
+
+    pub fn clear_pid(&self) {
+        CHILD_PID.store(0, Ordering::Release);
+        KILL_GROUP.store(false, Ordering::Release);
+    }
+
+    pub fn stop_requested(&self) -> bool {
+        STOP.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(all(test, unix))]
+pub fn request_stop_for_test() {
+    STOP.store(true, Ordering::Release);
+    STOP_SIGNAL.store(nix::libc::SIGTERM, Ordering::Release);
+}
+
+#[cfg(test)]
+pub fn reset_for_test() {
+    CHILD_PID.store(0, Ordering::Release);
+    KILL_GROUP.store(false, Ordering::Release);
+    STOP.store(false, Ordering::Release);
+    STOP_SIGNAL.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+pub static SUPERVISE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+pub fn detach_session_tokio(command: &mut tokio::process::Command) {
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(|| {
+            nix::unistd::setsid().map_err(|e| std::io::Error::other(e.to_string()))?;
+            Ok(())
+        });
+    }
+    let _ = command;
+}
+
+fn install() {
+    #[cfg(unix)]
+    unix::install();
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::{CHILD_PID, KILL_GROUP, STOP, STOP_SIGNAL, SignalAction, signal_action};
+    use nix::libc::c_int;
+    use nix::sys::signal::{
+        SaFlags, SigAction, SigHandler, SigSet, SigmaskHow, Signal, kill, killpg, sigaction,
+        sigprocmask,
+    };
+    use nix::unistd::Pid;
+    use std::sync::Once;
+    use std::sync::atomic::Ordering;
+
+    static INSTALL: Once = Once::new();
+
+    pub fn install() {
+        INSTALL.call_once(|| {
+            let mut unblock = SigSet::empty();
+            for signal in [
+                Signal::SIGHUP,
+                Signal::SIGINT,
+                Signal::SIGTERM,
+                Signal::SIGQUIT,
+                Signal::SIGUSR1,
+                Signal::SIGUSR2,
+                Signal::SIGWINCH,
+            ] {
+                let action = SigAction::new(
+                    SigHandler::Handler(handle),
+                    SaFlags::empty(),
+                    SigSet::empty(),
+                );
+                let _ = unsafe { sigaction(signal, &action) };
+                unblock.add(signal);
+            }
+            // Tokio's signal driver blocks these. Unblock so the handler runs
+            // even when no child pid is registered yet (restart backoff).
+            let _ = sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&unblock), None);
+        });
+    }
+
+    extern "C" fn handle(raw: c_int) {
+        let Ok(signal) = Signal::try_from(raw) else {
+            return;
+        };
+        match signal_action(signal) {
+            SignalAction::Ignore => {}
+            SignalAction::Forward => deliver(signal, false),
+            SignalAction::Stop => deliver(signal, true),
+        }
+    }
+
+    fn deliver(signal: Signal, stop: bool) {
+        if stop {
+            STOP.store(true, Ordering::Release);
+            STOP_SIGNAL.store(signal as c_int, Ordering::Release);
+        }
+        let pid = CHILD_PID.load(Ordering::Acquire);
+        if pid > 0 {
+            let pid = Pid::from_raw(pid);
+            if KILL_GROUP.load(Ordering::Acquire) {
+                let _ = killpg(pid, signal);
+            } else {
+                let _ = kill(pid, signal);
+            }
+        }
+    }
+
+    pub fn flush_pending() {
+        if !STOP.load(Ordering::Acquire) {
+            return;
+        }
+        let raw = STOP_SIGNAL.load(Ordering::Acquire);
+        let Ok(signal) = Signal::try_from(raw) else {
+            return;
+        };
+        deliver(signal, false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn hangup_is_ignored_stop_signals_end_the_wrapper() {
+        use super::{SignalAction, signal_action};
+        use nix::sys::signal::Signal::*;
+        assert_eq!(signal_action(SIGHUP), SignalAction::Ignore);
+        assert_eq!(signal_action(SIGINT), SignalAction::Stop);
+        assert_eq!(signal_action(SIGTERM), SignalAction::Stop);
+        assert_eq!(signal_action(SIGQUIT), SignalAction::Stop);
+        assert_eq!(signal_action(SIGUSR1), SignalAction::Forward);
+        assert_eq!(signal_action(SIGUSR2), SignalAction::Forward);
+        assert_eq!(signal_action(SIGWINCH), SignalAction::Forward);
+        assert_eq!(signal_action(SIGALRM), SignalAction::Ignore);
+        assert_eq!(signal_action(SIGPIPE), SignalAction::Ignore);
+        assert_eq!(signal_action(SIGCHLD), SignalAction::Ignore);
+        assert_eq!(signal_action(SIGTSTP), SignalAction::Ignore);
+    }
+}

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -69,14 +69,20 @@ fn run_plain(
     env: HashMap<String, String>,
     cwd: &Path,
 ) -> Result<i32> {
-    let status = shell
+    let watch = crate::child_signals::ChildWatch::new();
+    // Stay in lade's session. A new session here would let the child take
+    // the inherited TTY and hang it up on exit.
+    let mut child = shell
         .prepare_command(command)
         .current_dir(cwd)
         .envs(std::env::vars())
         .env_remove(crate::shell::LADE_VIA)
         .env_remove("BASH_ENV")
         .envs(env)
-        .status()?;
+        .spawn()?;
+    watch.set_pid(child.id(), false);
+    let status = child.wait()?;
+    watch.clear_pid();
     Ok(status.code().unwrap_or(1))
 }
 

--- a/src/exec/piped.rs
+++ b/src/exec/piped.rs
@@ -14,6 +14,7 @@ pub fn run(
     // stdin forwarded by a helper thread risks SIGPIPE (SIG_DFL at startup
     // kills the process) when the child exits before consuming forwarded
     // bytes, which is observable on Linux CI.
+    let watch = crate::child_signals::ChildWatch::new();
     let mut child = shell
         .prepare_command(command)
         .current_dir(cwd)
@@ -25,6 +26,7 @@ pub fn run(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
+    watch.set_pid(child.id(), false);
 
     let child_stdout = child.stdout.take().unwrap();
     let child_stderr = child.stderr.take().unwrap();
@@ -42,6 +44,7 @@ pub fn run(
     });
 
     let status = child.wait()?;
+    watch.clear_pid();
     stdout_thread.join().ok();
     stderr_thread.join().ok();
 

--- a/src/exec/pty.rs
+++ b/src/exec/pty.rs
@@ -34,6 +34,7 @@ pub fn run(
     // manage their own termios for reading a line.
     let _raw_guard = RawStdinGuard::enter();
 
+    let watch = crate::child_signals::ChildWatch::new();
     let mut child = shell
         .prepare_command(command)
         .current_dir(cwd)
@@ -45,6 +46,7 @@ pub fn run(
         .stdout(Stdio::from(slave_out))
         .stderr(Stdio::from(slave_err))
         .spawn()?;
+    watch.set_pid(child.id(), false);
 
     let master_fd = master.as_raw_fd();
     drop(slave);
@@ -58,6 +60,7 @@ pub fn run(
     let _ = redactor.stream(&mut master_reader, &mut std::io::stdout().lock());
 
     let status = child.wait()?;
+    watch.clear_pid();
     drop(master);
     Ok(status.code().unwrap_or(1))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod access;
 mod args;
 mod audience;
 mod bench;
+mod child_signals;
 mod compat;
 mod config;
 mod context;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,14 +1,31 @@
-use std::{collections::HashMap, ffi::OsString, path::Path, process::Stdio};
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    path::Path,
+    process::{ExitStatus, Stdio},
+    time::Instant,
+};
 
 use anyhow::{Result, bail};
 use log::info;
-use tokio::io::AsyncWriteExt;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin};
 use tokio::time::{Duration, timeout};
 use url::Url;
 
 use crate::{
-    args::McpCommand, config::Config, context::InvocationContext, message_box::MessageBox, prompt,
+    args::McpCommand, child_signals::ChildWatch, config::Config, context::InvocationContext,
+    exit_codes, message_box::MessageBox, prompt,
 };
+
+/// Same bounds as `network::process`. Readiness here is not a port: an MCP
+/// child is ready when spawn succeeded and the process is still running. Stdio
+/// servers stay silent until `initialize`.
+const INITIAL_RESTART_BACKOFF: Duration = Duration::from_millis(250);
+const MAX_RESTART_BACKOFF: Duration = Duration::from_secs(5);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const CLIENT_EOF_GRACE: Duration = Duration::from_secs(1);
 
 pub async fn run(
     command: McpCommand,
@@ -45,7 +62,7 @@ pub async fn run(
                     env.remove(crate::shell::LADE_VIA);
                 }
             }
-            run_stdio(command.argv, env, current_dir).await
+            run_stdio(command.argv, env, current_dir.to_path_buf()).await
         }
     };
     access.cleanup()?;
@@ -85,54 +102,409 @@ fn canonical_argv(argv: &[OsString]) -> Result<String> {
 async fn run_stdio(
     argv: Vec<OsString>,
     env: HashMap<String, String>,
-    current_dir: &Path,
+    current_dir: std::path::PathBuf,
 ) -> Result<Option<i32>> {
+    supervise_stdio(
+        argv,
+        env,
+        current_dir,
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+    )
+    .await
+}
+
+/// Restart the child only until the client handshake has been copied through.
+///
+/// `initialize` is not a Unix signal. It is the first JSON-RPC line the MCP
+/// client writes to our stdin (`"method":"initialize"`). We write those same
+/// bytes to the child's stdin. After that the session is the client's.
+async fn supervise_stdio<R, W>(
+    argv: Vec<OsString>,
+    env: HashMap<String, String>,
+    current_dir: std::path::PathBuf,
+    input: R,
+    mut output: W,
+) -> Result<Option<i32>>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut input = BufReader::new(input);
+    let mut pending = Vec::new();
+    let mut forwarded_initialize = false;
+    let mut backoff = INITIAL_RESTART_BACKOFF;
+    let startup_deadline = Instant::now() + STARTUP_TIMEOUT;
+    let mut ready_once = false;
+    let mut client_line = String::new();
+    let watch = ChildWatch::new();
+
+    loop {
+        if watch.stop_requested() {
+            return Ok(None);
+        }
+        let mut child = match spawn_stdio(&argv, &env, &current_dir) {
+            Ok(child) => child,
+            Err(error) => {
+                if Instant::now() >= startup_deadline {
+                    MessageBox::new()
+                        .error()
+                        .line("MCP server failed to start before initialize.")
+                        .paragraph(error.to_string())
+                        .print_stderr();
+                    return Ok(Some(exit_codes::FAILURE));
+                }
+                log::warn!("mcp stdio failed to start: {error}");
+                if !wait_restart_or_client(
+                    &mut input,
+                    &mut pending,
+                    &mut client_line,
+                    backoff,
+                    &watch,
+                )
+                .await?
+                {
+                    return Ok(None);
+                }
+                backoff = (backoff * 2).min(MAX_RESTART_BACKOFF);
+                continue;
+            }
+        };
+        if let Some(pid) = child.id() {
+            watch.set_pid(pid, true);
+        }
+        let spawned_at = Instant::now();
+        let mut child_stdin = Some(child.stdin.take().expect("piped stdin"));
+        let mut child_stdout = BufReader::new(child.stdout.take().expect("piped stdout"));
+        let mut in_flight = Vec::new();
+        let mut child_line = String::new();
+        let mut client_eof = false;
+        let mut broken_pipe = false;
+
+        while !pending.is_empty() {
+            let Some(stdin) = child_stdin.as_mut() else {
+                break;
+            };
+            let line = pending.remove(0);
+            match write_to_child(&line, stdin, &mut forwarded_initialize, &mut in_flight).await {
+                Ok(()) => {}
+                Err(error) if is_broken_pipe(&error) => {
+                    pending.insert(0, line);
+                    broken_pipe = true;
+                    break;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        let status = if broken_pipe {
+            drain_child_stdout(
+                &mut child_stdout,
+                &mut child_line,
+                &mut in_flight,
+                &mut output,
+            )
+            .await?;
+            finish_child(&mut child).await?
+        } else {
+            loop {
+                tokio::select! {
+                    biased;
+                    read = input.read_line(&mut client_line), if !client_eof => {
+                        if read? == 0 {
+                            client_eof = true;
+                            drop(child_stdin.take());
+                            continue;
+                        }
+                        let Some(stdin) = child_stdin.as_mut() else {
+                            pending.push(std::mem::take(&mut client_line));
+                            continue;
+                        };
+                        let line = std::mem::take(&mut client_line);
+                        match write_to_child(
+                            &line,
+                            stdin,
+                            &mut forwarded_initialize,
+                            &mut in_flight,
+                        )
+                        .await
+                        {
+                            Ok(()) => {}
+                            Err(error) if is_broken_pipe(&error) => {
+                                pending.push(line);
+                                drain_child_stdout(
+                                    &mut child_stdout,
+                                    &mut child_line,
+                                    &mut in_flight,
+                                    &mut output,
+                                )
+                                .await?;
+                                break finish_child(&mut child).await?;
+                            }
+                            Err(error) => return Err(error),
+                        }
+                    }
+                    read = child_stdout.read_line(&mut child_line) => {
+                        if read? == 0 {
+                            if let Some(status) = child.try_wait()? {
+                                break status;
+                            }
+                            continue;
+                        }
+                        forward_child_line(
+                            &child_line,
+                            &mut in_flight,
+                            &mut output,
+                        )
+                        .await?;
+                        child_line.clear();
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(20)) => {
+                        if watch.stop_requested() {
+                            drain_child_stdout(
+                                &mut child_stdout,
+                                &mut child_line,
+                                &mut in_flight,
+                                &mut output,
+                            )
+                            .await?;
+                            break finish_child(&mut child).await?;
+                        }
+                        if let Some(status) = child.try_wait()? {
+                            drain_child_stdout(
+                                &mut child_stdout,
+                                &mut child_line,
+                                &mut in_flight,
+                                &mut output,
+                            )
+                            .await?;
+                            break status;
+                        }
+                    }
+                }
+            }
+        };
+
+        watch.clear_pid();
+        if spawned_at.elapsed() > INITIAL_RESTART_BACKOFF {
+            ready_once = true;
+            backoff = INITIAL_RESTART_BACKOFF;
+        }
+
+        if watch.stop_requested() {
+            if forwarded_initialize {
+                for id in in_flight {
+                    write_server_exited(&mut output, id).await?;
+                }
+            }
+            return Ok(exit_code(status));
+        }
+
+        if forwarded_initialize {
+            for id in in_flight {
+                write_server_exited(&mut output, id).await?;
+            }
+            MessageBox::new()
+                .error()
+                .line("MCP server exited after initialize.")
+                .line("This lade process will exit. Starting lade mcp again will resolve secrets.")
+                .print_stderr();
+            return Ok(exit_code(status));
+        }
+
+        if client_eof {
+            return Ok(exit_code(status));
+        }
+
+        if !ready_once && Instant::now() >= startup_deadline {
+            MessageBox::new()
+                .error()
+                .line("MCP server exited before initialize.")
+                .paragraph(format!("last status: {status}"))
+                .print_stderr();
+            return Ok(Some(exit_codes::FAILURE));
+        }
+
+        log::warn!("mcp stdio exited before initialize (status: {status})");
+        if !wait_restart_or_client(&mut input, &mut pending, &mut client_line, backoff, &watch)
+            .await?
+        {
+            return Ok(None);
+        }
+        backoff = (backoff * 2).min(MAX_RESTART_BACKOFF);
+    }
+}
+
+fn spawn_stdio(
+    argv: &[OsString],
+    env: &HashMap<String, String>,
+    current_dir: &Path,
+) -> Result<Child> {
     let program = argv
         .first()
         .ok_or_else(|| anyhow::anyhow!("missing MCP stdio command"))?;
-    let mut child = tokio::process::Command::new(program)
+    let mut command = tokio::process::Command::new(program);
+    command
         .args(&argv[1..])
         .current_dir(current_dir)
         .envs(std::env::vars())
         .env_remove(crate::shell::LADE_VIA)
-        .envs(env)
+        .envs(env.clone())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
-    let mut child_stdin = child.stdin.take().expect("piped stdin");
-    let mut child_stdout = child.stdout.take().expect("piped stdout");
-    let mut input = tokio::spawn(async move {
-        let mut stdin = tokio::io::stdin();
-        tokio::io::copy(&mut stdin, &mut child_stdin).await
-    });
-    let output = tokio::spawn(async move {
-        let mut stdout = tokio::io::stdout();
-        tokio::io::copy(&mut child_stdout, &mut stdout).await?;
-        stdout.flush().await
-    });
-    let (status, input_finished) = tokio::select! {
-        status = child.wait() => (status?, false),
-        input_result = &mut input => {
-            input_result??;
-            let status = match timeout(Duration::from_secs(1), child.wait()).await {
-                Ok(status) => status?,
-                Err(_) => {
-                    let _ = child.kill().await;
-                    child.wait().await?
-                }
-            };
-            (status, true)
-        }
-    };
-    if !input_finished {
-        input.abort();
-        let _ = input.await;
-    }
-    output.await??;
-    Ok((!status.success()).then_some(status.code().unwrap_or(1)))
+        .stderr(Stdio::inherit());
+    // Own session so a tty hangup does not stop the MCP child.
+    crate::child_signals::detach_session_tokio(&mut command);
+    Ok(command.spawn()?)
 }
 
+async fn forward_child_line<W>(line: &str, in_flight: &mut Vec<Value>, output: &mut W) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    if let Some(id) = message_id(line.trim_end()) {
+        in_flight.retain(|open| open != &id);
+    }
+    output.write_all(line.as_bytes()).await?;
+    output.flush().await?;
+    Ok(())
+}
+
+async fn drain_child_stdout<R, W>(
+    child_stdout: &mut BufReader<R>,
+    child_line: &mut String,
+    in_flight: &mut Vec<Value>,
+    output: &mut W,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    if !child_line.is_empty() {
+        forward_child_line(child_line, in_flight, output).await?;
+        child_line.clear();
+    }
+    loop {
+        if child_stdout.read_line(child_line).await? == 0 {
+            return Ok(());
+        }
+        forward_child_line(child_line, in_flight, output).await?;
+        child_line.clear();
+    }
+}
+
+async fn write_to_child(
+    line: &str,
+    child_stdin: &mut ChildStdin,
+    forwarded_initialize: &mut bool,
+    in_flight: &mut Vec<Value>,
+) -> Result<()> {
+    let payload = line.trim_end_matches(['\r', '\n']);
+    child_stdin.write_all(line.as_bytes()).await?;
+    if !line.ends_with('\n') {
+        child_stdin.write_all(b"\n").await?;
+    }
+    child_stdin.flush().await?;
+    if !payload.is_empty() {
+        if message_method(payload).as_deref() == Some("initialize") {
+            *forwarded_initialize = true;
+        }
+        if let Some(id) = message_id(payload) {
+            in_flight.push(id);
+        }
+    }
+    Ok(())
+}
+
+async fn wait_restart_or_client<R>(
+    input: &mut BufReader<R>,
+    pending: &mut Vec<String>,
+    client_line: &mut String,
+    backoff: Duration,
+    watch: &ChildWatch,
+) -> Result<bool>
+where
+    R: AsyncRead + Unpin,
+{
+    let deadline = Instant::now() + backoff;
+    loop {
+        if watch.stop_requested() {
+            return Ok(false);
+        }
+        let remain = deadline.saturating_duration_since(Instant::now());
+        if remain.is_zero() {
+            return Ok(!watch.stop_requested());
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(remain.min(Duration::from_millis(20))) => {}
+            read = input.read_line(client_line) => {
+                if read? == 0 {
+                    return Ok(false);
+                }
+                pending.push(std::mem::take(client_line));
+                return Ok(!watch.stop_requested());
+            }
+        }
+    }
+}
+
+async fn finish_child(child: &mut Child) -> Result<ExitStatus> {
+    match timeout(CLIENT_EOF_GRACE, child.wait()).await {
+        Ok(status) => Ok(status?),
+        Err(_) => {
+            let _ = child.kill().await;
+            Ok(child.wait().await?)
+        }
+    }
+}
+
+fn exit_code(status: ExitStatus) -> Option<i32> {
+    (!status.success()).then_some(status.code().unwrap_or(1))
+}
+
+fn is_broken_pipe(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|error| {
+                error.kind() == std::io::ErrorKind::BrokenPipe
+                    || error.kind() == std::io::ErrorKind::ConnectionReset
+            })
+    })
+}
+
+fn message_method(raw: &str) -> Option<String> {
+    serde_json::from_str::<Value>(raw)
+        .ok()
+        .and_then(|message| message.get("method")?.as_str().map(str::to_owned))
+}
+
+fn message_id(raw: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(raw)
+        .ok()
+        .and_then(|message| message.get("id").cloned())
+}
+
+async fn write_server_exited<W>(output: &mut W, id: Value) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let error = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32000,
+            "message": "MCP server exited",
+        },
+    });
+    output.write_all(&serde_json::to_vec(&error)?).await?;
+    output.write_all(b"\n").await?;
+    output.flush().await?;
+    Ok(())
+}
+
+/// HTTP has no local child. Transport errors are answered in-process by
+/// `lade_sdk::mcp::bridge_http` and do not re-resolve secrets.
 async fn run_http(raw_url: String, headers: HashMap<String, String>) -> Result<Option<i32>> {
     let url = Url::parse(&raw_url)?;
     lade_sdk::mcp::bridge_http(
@@ -147,6 +519,7 @@ async fn run_http(raw_url: String, headers: HashMap<String, String>) -> Result<O
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncReadExt;
 
     #[test]
     fn canonical_argv_quotes_only_when_needed() {
@@ -154,5 +527,149 @@ mod tests {
             canonical_argv(&[OsString::from("npx"), OsString::from("with space")]).unwrap(),
             "npx 'with space'"
         );
+    }
+
+    #[test]
+    fn message_method_reads_initialize() {
+        assert_eq!(
+            message_method(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#).as_deref(),
+            Some("initialize")
+        );
+        assert_eq!(
+            message_id(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#),
+            Some(Value::from(1))
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn restarts_before_initialize_and_keeps_env() {
+        let _lock = crate::child_signals::SUPERVISE_TEST_LOCK.lock().await;
+        crate::child_signals::reset_for_test();
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("started");
+        let script = format!(
+            "if [ ! -f '{}' ]; then touch '{}'; exit 1; fi; printf '%s\\n' \"$TOKEN\"; exec cat",
+            marker.display(),
+            marker.display()
+        );
+        let (input_writer, input_reader) = tokio::io::duplex(1024);
+        let (output_writer, mut output_reader) = tokio::io::duplex(1024);
+        let env = HashMap::from([("TOKEN".to_string(), "cached-secret".to_string())]);
+        let supervise = tokio::spawn(supervise_stdio(
+            vec![
+                OsString::from("sh"),
+                OsString::from("-c"),
+                OsString::from(script),
+            ],
+            env,
+            dir.path().to_path_buf(),
+            input_reader,
+            output_writer,
+        ));
+        let mut output = String::new();
+        let started = Instant::now();
+        while !output.contains("cached-secret") {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "child was not restarted before initialize: {output}"
+            );
+            let mut buf = [0; 64];
+            let read = timeout(Duration::from_secs(5), output_reader.read(&mut buf))
+                .await
+                .expect("timed out waiting for restarted child")
+                .unwrap();
+            assert_ne!(read, 0);
+            output.push_str(std::str::from_utf8(&buf[..read]).unwrap());
+        }
+        drop(input_writer);
+        let code = supervise.await.unwrap().unwrap();
+        assert_eq!(code, None);
+        assert!(marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_during_pre_initialize_backoff_does_not_restart() {
+        let _lock = crate::child_signals::SUPERVISE_TEST_LOCK.lock().await;
+        crate::child_signals::reset_for_test();
+        let dir = tempfile::tempdir().unwrap();
+        let starts = dir.path().join("starts");
+        let started = dir.path().join("started");
+        let script = format!(
+            "printf x >> '{}'; if [ ! -f '{}' ]; then touch '{}'; exit 1; fi; exec cat",
+            starts.display(),
+            started.display(),
+            started.display()
+        );
+        let (input_writer, input_reader) = tokio::io::duplex(1024);
+        let (output_writer, _output_reader) = tokio::io::duplex(1024);
+        let supervise = tokio::spawn(supervise_stdio(
+            vec![
+                OsString::from("sh"),
+                OsString::from("-c"),
+                OsString::from(script),
+            ],
+            HashMap::new(),
+            dir.path().to_path_buf(),
+            input_reader,
+            output_writer,
+        ));
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !started.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "child never recorded the first crash"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        crate::child_signals::request_stop_for_test();
+        let code = timeout(Duration::from_secs(2), supervise)
+            .await
+            .expect("supervise ignored stop during backoff")
+            .unwrap()
+            .unwrap();
+        drop(input_writer);
+        crate::child_signals::reset_for_test();
+        assert!(
+            code.is_none() || code == Some(1),
+            "wrapper should stop without restarting, got {code:?}"
+        );
+        assert_eq!(std::fs::read_to_string(&starts).unwrap(), "x");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn after_initialize_answers_in_flight_ids_and_does_not_restart() {
+        let _lock = crate::child_signals::SUPERVISE_TEST_LOCK.lock().await;
+        crate::child_signals::reset_for_test();
+        let dir = tempfile::tempdir().unwrap();
+        let starts = dir.path().join("starts");
+        let script = format!("printf x >> '{}'; read line; exit 1", starts.display());
+        let (mut input_writer, input_reader) = tokio::io::duplex(1024);
+        let (output_writer, mut output_reader) = tokio::io::duplex(1024);
+        let supervise = tokio::spawn(supervise_stdio(
+            vec![
+                OsString::from("sh"),
+                OsString::from("-c"),
+                OsString::from(script),
+            ],
+            HashMap::new(),
+            dir.path().to_path_buf(),
+            input_reader,
+            output_writer,
+        ));
+        input_writer
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n")
+            .await
+            .unwrap();
+        drop(input_writer);
+        let code = supervise.await.unwrap().unwrap();
+        assert_eq!(code, Some(1));
+        let mut output = String::new();
+        output_reader.read_to_string(&mut output).await.unwrap();
+        assert!(output.contains(r#""id":1"#), "{output}");
+        assert!(output.contains("MCP server exited"), "{output}");
+        assert_eq!(std::fs::read_to_string(&starts).unwrap(), "x");
     }
 }

--- a/tests/child_signals.rs
+++ b/tests/child_signals.rs
@@ -445,10 +445,8 @@ exec cat
     );
     let mut lade = spawn_mcp(home.path(), dir.path(), &script, &[]);
     wait_exists(&dir.path().join("started"));
-    std::thread::sleep(Duration::from_millis(80));
     drop(lade.child.stdin.take());
     let _ = lade.wait_exit();
-    std::thread::sleep(Duration::from_millis(400));
     assert_eq!(fs::read_to_string(&starts).unwrap(), "x");
 }
 

--- a/tests/child_signals.rs
+++ b/tests/child_signals.rs
@@ -1,0 +1,493 @@
+#![cfg(unix)]
+
+mod common;
+
+use nix::libc::{self, pid_t};
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+const READY: Duration = Duration::from_secs(8);
+const EXIT: Duration = Duration::from_secs(5);
+
+struct LadeChild {
+    child: Child,
+    extra: Vec<u32>,
+    stderr: Arc<Mutex<Vec<u8>>>,
+}
+
+impl LadeChild {
+    fn spawn(mut child: Child) -> Self {
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        if let Some(mut pipe) = child.stdout.take() {
+            thread::spawn(move || {
+                let mut buf = Vec::new();
+                let _ = pipe.read_to_end(&mut buf);
+            });
+        }
+        if let Some(mut pipe) = child.stderr.take() {
+            let stderr = Arc::clone(&stderr);
+            thread::spawn(move || {
+                let mut buf = Vec::new();
+                let _ = pipe.read_to_end(&mut buf);
+                stderr.lock().unwrap().extend_from_slice(&buf);
+            });
+        }
+        Self {
+            child,
+            extra: Vec::new(),
+            stderr,
+        }
+    }
+
+    fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn signal(&self, signal: Signal) {
+        kill(Pid::from_raw(self.pid() as i32), signal).unwrap();
+    }
+
+    fn running(&mut self) -> bool {
+        self.child.try_wait().unwrap().is_none()
+    }
+
+    fn wait_exit(&mut self) -> std::process::ExitStatus {
+        let started = Instant::now();
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                return status;
+            }
+            if started.elapsed() >= EXIT {
+                let _ = kill(Pid::from_raw(self.pid() as i32), Signal::SIGKILL);
+                let _ = self.child.wait();
+                let stderr = self.stderr.lock().unwrap().clone();
+                panic!(
+                    "lade did not exit after stop signal; stderr={}",
+                    String::from_utf8_lossy(&stderr)
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for LadeChild {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = kill(Pid::from_raw(self.pid() as i32), Signal::SIGKILL);
+            let _ = self.child.wait();
+        }
+        for pid in &self.extra {
+            let _ = kill(Pid::from_raw(*pid as i32), Signal::SIGKILL);
+        }
+    }
+}
+
+fn wait_exists(path: &Path) {
+    let started = Instant::now();
+    while !path.exists() {
+        assert!(
+            started.elapsed() < READY,
+            "timed out waiting for {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_log_has(path: &Path, needle: &str) {
+    let started = Instant::now();
+    loop {
+        let body = fs::read_to_string(path).unwrap_or_default();
+        if body.lines().any(|line| line == needle) {
+            return;
+        }
+        assert!(
+            started.elapsed() < READY,
+            "timed out waiting for {needle} in {}: {body}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn read_pid(path: &Path) -> u32 {
+    wait_exists(path);
+    let started = Instant::now();
+    loop {
+        if let Ok(raw) = fs::read_to_string(path)
+            && let Ok(pid) = raw.trim().parse::<u32>()
+            && pid > 0
+        {
+            return pid;
+        }
+        assert!(
+            started.elapsed() < READY,
+            "timed out reading pid from {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn session_of(pid: u32) -> pid_t {
+    let sid = unsafe { libc::getsid(pid as pid_t) };
+    assert!(sid > 0, "getsid({pid}) failed: {sid}");
+    sid
+}
+
+fn pid_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as pid_t, 0) == 0 }
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn trap_script(dir: &Path) -> PathBuf {
+    let path = dir.join("trap.sh");
+    write_executable(
+        &path,
+        r#"#!/bin/sh
+dir=$1
+echo $$ > "$dir/pid"
+trap 'printf "%s\n" HUP >> "$dir/log"' HUP
+trap 'printf "%s\n" INT >> "$dir/log"; exit 130' INT
+trap 'printf "%s\n" TERM >> "$dir/log"; exit 143' TERM
+trap 'printf "%s\n" QUIT >> "$dir/log"; exit 131' QUIT
+trap 'printf "%s\n" USR1 >> "$dir/log"' USR1
+trap 'printf "%s\n" USR2 >> "$dir/log"' USR2
+trap 'printf "%s\n" WINCH >> "$dir/log"' WINCH
+touch "$dir/ready"
+while true; do sleep 0.2; done
+"#,
+    );
+    path
+}
+
+fn spawn_inject(home: &Path, cwd: &Path, script: &Path, work: &Path, no_mask: bool) -> LadeChild {
+    let mut cmd = common::lade_std(home);
+    cmd.current_dir(cwd);
+    if no_mask {
+        cmd.args(["inject", "--no-mask", "--", "exec"]);
+    } else {
+        cmd.args(["inject", "--", "exec"]);
+    }
+    cmd.arg(script).arg(work);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    LadeChild::spawn(cmd.spawn().unwrap())
+}
+
+fn spawn_mcp(home: &Path, cwd: &Path, script: &Path, args: &[&str]) -> LadeChild {
+    let mut cmd = common::lade_std(home);
+    cmd.current_dir(cwd).arg("mcp").arg("--").arg(script);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    LadeChild::spawn(cmd.spawn().unwrap())
+}
+
+fn wait_ready(work: &Path, lade: &mut LadeChild) {
+    wait_exists(&work.join("ready"));
+    assert!(lade.running(), "lade exited before the child was ready");
+}
+
+#[test]
+fn inject_child_stays_in_lade_session() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_inject(home.path(), dir.path(), &script, dir.path(), true);
+    wait_ready(dir.path(), &mut lade);
+    let child = read_pid(&dir.path().join("pid"));
+    assert_eq!(session_of(lade.pid()), session_of(child));
+}
+
+#[test]
+fn mcp_child_gets_its_own_session() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_mcp(
+        home.path(),
+        dir.path(),
+        &script,
+        &[dir.path().to_str().unwrap()],
+    );
+    wait_ready(dir.path(), &mut lade);
+    let child = read_pid(&dir.path().join("pid"));
+    assert_ne!(session_of(lade.pid()), session_of(child));
+    assert_eq!(session_of(child), child as pid_t);
+}
+
+#[test]
+fn inject_ignores_hangup_and_keeps_child() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_inject(home.path(), dir.path(), &script, dir.path(), true);
+    wait_ready(dir.path(), &mut lade);
+    let child = read_pid(&dir.path().join("pid"));
+    lade.signal(Signal::SIGHUP);
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(lade.running(), "lade exited on SIGHUP");
+    assert!(pid_alive(child), "inject child died on wrapper SIGHUP");
+    let log = fs::read_to_string(dir.path().join("log")).unwrap_or_default();
+    assert!(
+        !log.lines().any(|line| line == "HUP"),
+        "HUP was forwarded: {log}"
+    );
+}
+
+#[test]
+fn mcp_ignores_hangup_and_keeps_child() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_mcp(
+        home.path(),
+        dir.path(),
+        &script,
+        &[dir.path().to_str().unwrap()],
+    );
+    wait_ready(dir.path(), &mut lade);
+    let child = read_pid(&dir.path().join("pid"));
+    lade.signal(Signal::SIGHUP);
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(lade.running(), "lade exited on SIGHUP");
+    assert!(pid_alive(child), "MCP child died on wrapper SIGHUP");
+    let log = fs::read_to_string(dir.path().join("log")).unwrap_or_default();
+    assert!(
+        !log.lines().any(|line| line == "HUP"),
+        "HUP was forwarded: {log}"
+    );
+}
+
+#[test]
+fn inject_forwards_usr_and_winch_and_stays_up() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_inject(home.path(), dir.path(), &script, dir.path(), true);
+    wait_ready(dir.path(), &mut lade);
+    for signal in [Signal::SIGUSR1, Signal::SIGUSR2, Signal::SIGWINCH] {
+        lade.signal(signal);
+    }
+    wait_log_has(&dir.path().join("log"), "USR1");
+    wait_log_has(&dir.path().join("log"), "USR2");
+    wait_log_has(&dir.path().join("log"), "WINCH");
+    assert!(lade.running(), "lade exited after forward signals");
+}
+
+#[test]
+fn mcp_forwards_usr_and_winch_and_stays_up() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_mcp(
+        home.path(),
+        dir.path(),
+        &script,
+        &[dir.path().to_str().unwrap()],
+    );
+    wait_ready(dir.path(), &mut lade);
+    for signal in [Signal::SIGUSR1, Signal::SIGUSR2, Signal::SIGWINCH] {
+        lade.signal(signal);
+    }
+    wait_log_has(&dir.path().join("log"), "USR1");
+    wait_log_has(&dir.path().join("log"), "USR2");
+    wait_log_has(&dir.path().join("log"), "WINCH");
+    assert!(lade.running(), "lade exited after forward signals");
+}
+
+#[test]
+fn inject_piped_path_forwards_term() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = trap_script(dir.path());
+    let mut lade = spawn_inject(home.path(), dir.path(), &script, dir.path(), false);
+    wait_ready(dir.path(), &mut lade);
+    lade.signal(Signal::SIGTERM);
+    wait_log_has(&dir.path().join("log"), "TERM");
+    let status = lade.wait_exit();
+    assert!(!status.success(), "{status}");
+}
+
+#[test]
+fn inject_stop_signals_end_wrapper_and_child() {
+    for signal in [Signal::SIGINT, Signal::SIGTERM, Signal::SIGQUIT] {
+        let dir = tempdir().unwrap();
+        let home = tempdir().unwrap();
+        let script = trap_script(dir.path());
+        let mut lade = spawn_inject(home.path(), dir.path(), &script, dir.path(), true);
+        wait_ready(dir.path(), &mut lade);
+        let child = read_pid(&dir.path().join("pid"));
+        lade.signal(signal);
+        let status = lade.wait_exit();
+        assert!(!status.success(), "{signal:?} status={status}");
+        let started = Instant::now();
+        while pid_alive(child) {
+            assert!(
+                started.elapsed() < EXIT,
+                "{signal:?} left the inject child running"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+#[test]
+fn mcp_stop_signals_end_wrapper_and_child() {
+    for signal in [Signal::SIGINT, Signal::SIGTERM, Signal::SIGQUIT] {
+        let dir = tempdir().unwrap();
+        let home = tempdir().unwrap();
+        let script = trap_script(dir.path());
+        let mut lade = spawn_mcp(
+            home.path(),
+            dir.path(),
+            &script,
+            &[dir.path().to_str().unwrap()],
+        );
+        wait_ready(dir.path(), &mut lade);
+        let child = read_pid(&dir.path().join("pid"));
+        lade.signal(signal);
+        let _ = lade.wait_exit();
+        let started = Instant::now();
+        while pid_alive(child) {
+            assert!(
+                started.elapsed() < EXIT,
+                "{signal:?} left the MCP child running"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+#[test]
+fn mcp_term_kills_same_group_grandchild() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let script = dir.path().join("family.sh");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+dir=$1
+echo $$ > "$dir/pid"
+(
+  echo $$ > "$dir/grand.pid"
+  trap 'printf "%s\n" TERM >> "$dir/grand.log"; exit 0' TERM
+  touch "$dir/grand.ready"
+  while true; do sleep 0.2; done
+) &
+echo $! > "$dir/grand.watch"
+touch "$dir/ready"
+wait
+"#,
+    );
+    let mut lade = spawn_mcp(
+        home.path(),
+        dir.path(),
+        &script,
+        &[dir.path().to_str().unwrap()],
+    );
+    wait_ready(dir.path(), &mut lade);
+    wait_exists(&dir.path().join("grand.ready"));
+    let grand = read_pid(&dir.path().join("grand.pid"));
+    lade.extra.push(grand);
+    lade.signal(Signal::SIGTERM);
+    let _ = lade.wait_exit();
+    wait_log_has(&dir.path().join("grand.log"), "TERM");
+    let started = Instant::now();
+    while pid_alive(grand) {
+        assert!(
+            started.elapsed() < EXIT,
+            "MCP grandchild survived SIGTERM to lade"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn mcp_client_eof_during_pre_initialize_backoff_does_not_restart() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let starts = dir.path().join("starts");
+    let script = dir.path().join("crash-once.sh");
+    write_executable(
+        &script,
+        &format!(
+            r#"#!/bin/sh
+printf x >> '{starts}'
+if [ ! -f '{started}' ]; then
+  touch '{started}'
+  exit 1
+fi
+exec cat
+"#,
+            starts = starts.display(),
+            started = dir.path().join("started").display()
+        ),
+    );
+    let mut lade = spawn_mcp(home.path(), dir.path(), &script, &[]);
+    wait_exists(&dir.path().join("started"));
+    std::thread::sleep(Duration::from_millis(80));
+    drop(lade.child.stdin.take());
+    let _ = lade.wait_exit();
+    std::thread::sleep(Duration::from_millis(400));
+    assert_eq!(fs::read_to_string(&starts).unwrap(), "x");
+}
+
+#[test]
+fn mcp_term_after_initialize_does_not_restart() {
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let starts = dir.path().join("starts");
+    let ready = dir.path().join("ready");
+    let got_init = dir.path().join("got_init");
+    let script = dir.path().join("hold.sh");
+    write_executable(
+        &script,
+        &format!(
+            r#"#!/bin/sh
+printf x >> '{starts}'
+touch '{ready}'
+read line
+touch '{got_init}'
+exec cat
+"#,
+            starts = starts.display(),
+            ready = ready.display(),
+            got_init = got_init.display()
+        ),
+    );
+    let mut lade = spawn_mcp(home.path(), dir.path(), &script, &[]);
+    wait_exists(&ready);
+    {
+        let stdin = lade.child.stdin.as_mut().expect("piped stdin");
+        use std::io::Write;
+        stdin
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}\n")
+            .unwrap();
+        stdin.flush().unwrap();
+    }
+    wait_exists(&got_init);
+    lade.signal(Signal::SIGTERM);
+    let _ = lade.wait_exit();
+    std::thread::sleep(Duration::from_millis(400));
+    assert_eq!(fs::read_to_string(&starts).unwrap(), "x");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
 use assert_cmd::Command;
+use std::path::Path;
+use std::process::Command as StdCommand;
 
-pub fn lade(home: &std::path::Path) -> Command {
+pub fn lade_std(home: &Path) -> StdCommand {
     let config_path = home.join("lade-config.json");
     if !config_path.exists() {
         // Far-future stamp: tests must not hit GitHub on `set` / `status`.
@@ -10,7 +12,7 @@ pub fn lade(home: &std::path::Path) -> Command {
         )
         .unwrap();
     }
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin("lade"));
+    let mut cmd = StdCommand::new(assert_cmd::cargo::cargo_bin("lade"));
     cmd.env("LADE_SHELL", "bash")
         .env("HOME", home)
         .env("LADE_CONFIG_PATH", config_path)
@@ -22,6 +24,11 @@ pub fn lade(home: &std::path::Path) -> Command {
         .env_remove("COPILOT_MODEL")
         .env_remove("CURSOR_VERSION");
     cmd
+}
+
+#[allow(dead_code)]
+pub fn lade(home: &Path) -> Command {
+    Command::from_std(lade_std(home))
 }
 
 #[cfg(unix)]

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -1,9 +1,33 @@
 mod common;
 
 use std::fs;
+use std::path::Path;
 
 use predicates::prelude::PredicateBooleanExt;
 use tempfile::tempdir;
+
+fn lade_process(home: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin("lade"));
+    let config_path = home.join("lade-config.json");
+    if !config_path.exists() {
+        fs::write(
+            &config_path,
+            r#"{"update_check":"2099-01-01T00:00:00Z","user":null,"cli_check":{}}"#,
+        )
+        .unwrap();
+    }
+    cmd.env("LADE_SHELL", "bash")
+        .env("HOME", home)
+        .env("LADE_CONFIG_PATH", config_path)
+        .env_remove("LADE_VIA")
+        .env_remove("AI_AGENT")
+        .env_remove("AGENT")
+        .env_remove("CLAUDECODE")
+        .env_remove("CURSOR_AGENT")
+        .env_remove("COPILOT_MODEL")
+        .env_remove("CURSOR_VERSION");
+    cmd
+}
 
 #[test]
 fn test_mcp_stdio_injects_public_bindings_only() {
@@ -45,6 +69,82 @@ fn test_mcp_agent_when_uses_env_signal() {
         .assert()
         .success()
         .stdout(predicates::str::contains("PUBLIC=agentsecret"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_mcp_restarts_stdio_child_before_initialize_without_rehydrating() {
+    use std::io::Read;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    let dir = tempdir().unwrap();
+    let home = tempdir().unwrap();
+    let hydrates = dir.path().join("hydrates");
+    let started = dir.path().join("started");
+    let server = dir.path().join("crash-once");
+    fs::write(
+        dir.path().join("lade.yml"),
+        format!(
+            "\"^crash-once$\":\n  TOKEN: \"sh://printf x >> {}; printf cached-secret\"\n",
+            hydrates.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &server,
+        format!(
+            "#!/bin/sh\nif [ ! -f '{started}' ]; then touch '{started}'; exit 1; fi\nprintf '%s\\n' \"$TOKEN\"\nexec cat\n",
+            started = started.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&server, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut child = lade_process(home.path())
+        .current_dir(dir.path())
+        .args(["mcp", "--", "crash-once"])
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                dir.path().display(),
+                std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string())
+            ),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let stdin = child.stdin.take().expect("piped stdin");
+    let mut output = Vec::new();
+    let started_at = Instant::now();
+    while !output
+        .windows(b"cached-secret".len())
+        .any(|w| w == b"cached-secret")
+    {
+        assert!(
+            started_at.elapsed() < Duration::from_secs(8),
+            "lade mcp dropped the child instead of restarting: {}",
+            String::from_utf8_lossy(&output)
+        );
+        let mut buf = [0; 64];
+        let read = stdout.read(&mut buf).unwrap();
+        assert_ne!(
+            read,
+            0,
+            "stdout closed before restart: {}",
+            String::from_utf8_lossy(&output)
+        );
+        output.extend_from_slice(&buf[..read]);
+    }
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "{status}");
+    assert_eq!(fs::read_to_string(&hydrates).unwrap(), "x");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Restart the MCP stdio child only until `initialize` is forwarded, reusing the already hydrated env instead of calling vaults again.
- Share Unix signal wrapping between `lade mcp` and `lade inject`: hangup is ignored, stop signals end the wrapper, user/window signals are forwarded.
- MCP children get their own session and process group. Inject stays on the TTY session so the terminal is not hung up on exit.

## Test plan
- [ ] `cargo test --locked --test child_signals --test mcp --test inject --test pty_echo`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `lade mcp -- <server>`: crash the child before `initialize` and confirm one hydrate plus a restart
- [ ] After `initialize`, child exit should not restart and in-flight ids should get `-32000`
- [ ] `SIGHUP` to lade leaves inject/mcp children up; `SIGTERM`/`SIGINT` stop both; `SIGUSR1` forwards without exiting lade