### PR TITLE
feat: support lookaround in command regexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +882,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1559,6 +1585,7 @@ dependencies = [
  "criterion",
  "directories",
  "env_logger",
+ "fancy-regex",
  "flate2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_yaml = "0.9.34"
 clap = { version = "4.6.6", features = ["derive"] }
 regex = "1.13.1"
+fancy-regex = "0.19"
 lade-sdk = { path = "./sdk", version = "0.17.3-beta.1" }
 tokio = { version = "1", features = ["rt", "macros", "fs", "time", "signal", "io-std", "io-util", "process"] }
 indexmap = { version = "2.14.2", features = ["serde"] }

--- a/src/config/collect.rs
+++ b/src/config/collect.rs
@@ -73,8 +73,8 @@ impl Config {
     }
 
     pub(crate) fn collect(&self, command: &str) -> Vec<(PathBuf, LadeRule)> {
-        self.regex_set
-            .matches(command)
+        self.compiled
+            .matching_indices(command)
             .into_iter()
             .map(|i| self.rules[i].clone())
             .collect()
@@ -96,8 +96,8 @@ impl Config {
         command: &str,
         audience: Audience,
     ) -> Vec<(PathBuf, String, LadeRule)> {
-        self.regex_set
-            .matches(command)
+        self.compiled
+            .matching_indices(command)
             .into_iter()
             .filter(|&i| rule_applies_to(&self.rules[i].1, audience))
             .map(|i| {

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,13 +1,12 @@
 use anyhow::{Context, Result, bail};
 use indexmap::IndexMap;
-use regex::RegexSet;
 use serde::Deserialize;
 use std::{
     fs::File,
     path::{Path, PathBuf},
 };
 
-use super::{Config, secret::LadeRule};
+use super::{Config, patterns::CompiledPatterns, secret::LadeRule};
 
 /// One mapping, or a list of mappings when `.when` differs.
 #[derive(Deserialize, Debug)]
@@ -97,8 +96,8 @@ impl LadeFile {
             }
         }
 
-        let regex_set = RegexSet::new(&regex_strs)?;
-        Ok(Config::new(rules, regex_strs, regex_set))
+        let compiled = CompiledPatterns::compile(&regex_strs)?;
+        Ok(Config::new(rules, regex_strs, compiled))
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,7 @@
 mod collect;
 mod hydrate;
 mod loader;
+mod patterns;
 mod plan;
 mod secret;
 #[cfg(test)]
@@ -12,7 +13,7 @@ pub use secret::*;
 use crate::global_config::GlobalConfig;
 use crate::ticket::TicketSecret;
 use anyhow::Result;
-use regex::RegexSet;
+use patterns::CompiledPatterns;
 use serde_json::Value;
 use std::{
     collections::{HashMap, HashSet},
@@ -59,19 +60,19 @@ pub(crate) struct PreEventWork {
 pub struct Config {
     rules: Vec<(PathBuf, LadeRule)>,
     patterns: Vec<String>,
-    regex_set: RegexSet,
+    compiled: CompiledPatterns,
 }
 
 impl Config {
     pub(crate) fn new(
         rules: Vec<(PathBuf, LadeRule)>,
         patterns: Vec<String>,
-        regex_set: RegexSet,
+        compiled: CompiledPatterns,
     ) -> Self {
         Config {
             rules,
             patterns,
-            regex_set,
+            compiled,
         }
     }
 

--- a/src/config/patterns.rs
+++ b/src/config/patterns.rs
@@ -1,0 +1,85 @@
+use anyhow::{Context, Result};
+use fancy_regex::Regex as FancyRegex;
+use regex::{Error as RegexError, Regex, RegexSet};
+
+/// Caps VM work on lookaround keys so a hook cannot sit on a command line.
+const BACKTRACK_LIMIT: usize = 100_000;
+
+pub(crate) struct CompiledPatterns {
+    regex_set: RegexSet,
+    set_rule: Vec<usize>,
+    fancy: Vec<(usize, FancyRegex)>,
+}
+
+impl CompiledPatterns {
+    pub(crate) fn compile(patterns: &[String]) -> Result<Self> {
+        match RegexSet::new(patterns) {
+            Ok(regex_set) => Ok(Self {
+                regex_set,
+                set_rule: (0..patterns.len()).collect(),
+                fancy: Vec::new(),
+            }),
+            Err(err) if needs_fancy(&err) => Self::split(patterns),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn split(patterns: &[String]) -> Result<Self> {
+        let mut easy = Vec::new();
+        let mut set_rule = Vec::new();
+        let mut fancy = Vec::new();
+        for (index, pattern) in patterns.iter().enumerate() {
+            match Regex::new(pattern) {
+                Ok(_) => {
+                    easy.push(pattern.as_str());
+                    set_rule.push(index);
+                }
+                Err(err) if needs_fancy(&err) => {
+                    let compiled = fancy_regex::RegexBuilder::new(pattern)
+                        .backtrack_limit(BACKTRACK_LIMIT)
+                        .build()
+                        .with_context(|| format!("failed to compile command regex '{pattern}'"))?;
+                    fancy.push((index, compiled));
+                }
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(Self {
+            regex_set: RegexSet::new(&easy)?,
+            set_rule,
+            fancy,
+        })
+    }
+
+    pub(crate) fn matching_indices(&self, command: &str) -> Vec<usize> {
+        if self.fancy.is_empty() {
+            return self.regex_set.matches(command).into_iter().collect();
+        }
+        let rule_count = self
+            .set_rule
+            .iter()
+            .copied()
+            .chain(self.fancy.iter().map(|(index, _)| *index))
+            .max()
+            .map(|index| index + 1)
+            .unwrap_or(0);
+        let mut hit = vec![false; rule_count];
+        for set_i in self.regex_set.matches(command) {
+            hit[self.set_rule[set_i]] = true;
+        }
+        for (rule_i, compiled) in &self.fancy {
+            if compiled.is_match(command).unwrap_or(false) {
+                hit[*rule_i] = true;
+            }
+        }
+        hit.into_iter()
+            .enumerate()
+            .filter_map(|(index, matched)| matched.then_some(index))
+            .collect()
+    }
+}
+
+fn needs_fancy(err: &RegexError) -> bool {
+    let msg = err.to_string();
+    msg.contains("look-around") || msg.contains("backreferences are not supported")
+}

--- a/src/config/tests/collect.rs
+++ b/src/config/tests/collect.rs
@@ -226,6 +226,38 @@ fn test_collect_disclaimers() {
 }
 
 #[test]
+fn lookahead_excludes_help_flag() {
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("lade.yml"),
+        "\"^terraform apply(?!.*--help)\":\n  TOKEN: val\n",
+    )
+    .unwrap();
+    let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+    assert_eq!(config.collect("terraform apply").len(), 1);
+    assert_eq!(config.collect("terraform apply -auto-approve").len(), 1);
+    assert!(config.collect("terraform apply --help").is_empty());
+}
+
+#[test]
+fn lookahead_keeps_easy_overlay_order() {
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("lade.yml"),
+        "\"^terraform\":\n  BASE: val\n\"^terraform apply(?!.*--help)\":\n  EXTRA: val\n",
+    )
+    .unwrap();
+    let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+    let apply = config.collect("terraform apply");
+    assert_eq!(apply.len(), 2);
+    assert!(apply[0].1.secrets.contains_key("BASE"));
+    assert!(apply[1].1.secrets.contains_key("EXTRA"));
+    let help = config.collect("terraform apply --help");
+    assert_eq!(help.len(), 1);
+    assert!(help[0].1.secrets.contains_key("BASE"));
+}
+
+#[test]
 fn test_log_on_walk_last_explicit_wins_across_non_matching_rules() {
     let dir = tempdir().unwrap();
     std::fs::write(


### PR DESCRIPTION
## Summary
- Fall back to fancy-regex when a `lade.yml` key uses lookaround or backrefs. Other keys stay on `regex::RegexSet`.
- `collect()` unions both in overlay order, with a backtrack cap on fancy keys.

Closes #87

## Test plan
- [x] `lookahead_excludes_help_flag`
- [x] `lookahead_keeps_easy_overlay_order`
- Quote YAML keys that contain `(?!...)`.