### PR TITLE
feat: record MCP verbs and store diary argv as JSONB

### DIFF
--- a/.agents/skills/lade/SKILL.md
+++ b/.agents/skills/lade/SKILL.md
@@ -75,31 +75,9 @@ For Codex, open `/hooks` and trust the Lade command. An untrusted or
 }
 ```
 
-For Pi, ensure `.pi/settings.json` contains:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash|bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "lade hook --harness pi"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Pi matches on `tool_name`, often lowercase `bash`.
-
 For OpenCode, ensure `.opencode/plugins/lade-pretool.js` is present. Native OpenCode loads that file and does not run Claude-style `hooks.json`. The plugin must export a function that returns a `tool.execute.before` hook.
 
-With preTool hooks, run the user's command normally. Lade decides whether it matches `lade.yml`, rewrites matches to `lade inject`, and masks provider-resolved secrets from stdout/stderr. This avoids making the agent infer command regexes itself. `lade hook` is for Cursor, Claude Code, Codex, Pi, and OpenCode.
+With preTool hooks, run the user's command normally. Lade decides whether it matches `lade.yml`, rewrites matches to `lade inject`, and masks provider-resolved secrets from stdout/stderr. This avoids making the agent infer command regexes itself. `lade hook` is for Cursor, Claude Code, Codex, and OpenCode.
 
 ## Fallback
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 # rustc-wrapper, not rustc-workspace-wrapper: Cargo's rustc -vV probe
-# goes through both, so the workspace-only wrapper does not skip it.
+# goes through both. The wrapper skips sccache on that probe so
+# cargo clean survives a blocked or wiped daemon.
 # The project wrapper overrides ~/.cargo/config.toml rustc-wrapper.
 # In the Cursor sandbox it execs rustc (Seatbelt denies sccache's
 # AF_UNIX connect). Outside the sandbox it uses sccache.

--- a/.cargo/sccache-wrapper
+++ b/.cargo/sccache-wrapper
@@ -4,8 +4,19 @@
 # reach its server in the Cursor sandbox. Skip it there. This also
 # overrides ~/.cargo/config.toml rustc-wrapper = "sccache".
 # Fall back to rustc when sccache is absent (CI, fresh clones).
+# rustc -vV is a version probe (cargo clean, metadata). No objects.
+# cargo clean also wipes target/sccache; starting the daemon then
+# is wasted and fails if the socket is blocked.
 if [ -n "${CURSOR_SANDBOX:-}" ]; then
   exec "$@"
+fi
+for arg in "$@"; do
+  if [ "$arg" = "-vV" ]; then
+    exec "$@"
+  fi
+done
+if [ -n "${SCCACHE_DIR:-}" ]; then
+  mkdir -p "$SCCACHE_DIR" 2>/dev/null || true
 fi
 if command -v sccache >/dev/null 2>&1; then
   exec sccache "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ bash tests/installer_test.sh
 - Keep documented exit codes (`src/exit_codes.rs`) stable across minor
   versions. `lade status --json` keeps `version`, `global_config`, `hooks`,
   `project_config`, and `ok`; the `hooks` object is `preexec` plus `pretool`.
+  `skills` is additive (same agent shape as `hooks.pretool`). A skill is
+  Lade-managed when its sha256 matches the bundled `SKILL.md` or a previous
+  official hash kept in the binary.
 - **`lade status` latest**: a successful daily GitHub check must persist
   the tag (`latest_version` in the global config) so status can show it after
   shell use. If the fetch failed, print when we last tried (`tried today at
@@ -42,11 +45,12 @@ bash tests/installer_test.sh
 
 ## Project layout
 
-- `src/` — CLI crate. Key modules: `pretool/` (`lade hook` preToolUse handler
-  plus install into Cursor/Claude/Codex/Pi/OpenCode configs), `audience.rs` (`detect()` for Via,
-  Audience, UI), `prompt.rs` (disclaimer flow), `inject.rs`/`exec/` (PTY
-  execution + masking), `network/` (acquire and process groups), `status.rs`,
-  `shell/` (preexec integration), `config/`, `message_box/`.
+- `src/` — CLI crate. Key modules: `pretool/` (`lade hook` preToolUse / MCP verb
+  handler plus install into Cursor/Claude/Codex/OpenCode configs), `audience.rs`
+  (`detect()` for Via, Audience, UI), `prompt.rs` (disclaimer flow),
+  `inject.rs`/`exec/` (PTY execution + masking), `network/` (acquire and
+  process groups), `status.rs`, `shell/` (preexec integration), `config/`,
+  `message_box/`.
 - `sdk/` — providers: vault hydrate, network URI parse, tunnel command
   builders, CLI version tables. MCP HTTP byte bridge.
 - `tests/` — Rust integration tests + `installer_test.sh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ Release notes are also published on [GitHub Releases](https://github.com/zifeo/l
   the previous env. `LADE_APPROVE` is `sha256(command + window)[:5]`.
   `LADE_VIA`, `LADE_NETWORK_PIDS`, `LADE_PENDING`, and
   `LADE_DISCLAIMER_APPROVED` are no longer classifiers or messengers.
-  `set` / `unset` still clear leftovers.
+- **No stale protocol broom**: `set` / `unset` no longer emit `unset`
+  for dropped keys. `unset` stops tunnels from the T ticket only.
 - **Hook bin name**: `lade install` and match rewrites use argv[0]. `lade`
   stays `lade`. A path invocation (`/opt/lade install`) uses `current_exe`.
   Re-running `lade install` updates an existing hook that still has a path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ url = "2.5"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 rusqlite_migration = "2.6.0"
 uuid = { version = "1.26.0", features = ["v7"] }
-tar = "0.4.44"
-flate2 = "1.1.2"
+tar = "0.4.46"
+flate2 = "1.1.10"
 tempfile = "3.27.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ shell session, CI job, or model context.
 - Open private network access through `kubectl`, `kubefwd`, Teleport `tsh`, or
   SSH only while the command runs.
 - Redact provider-resolved secrets from stdout and stderr.
-- Work from shells, CI, Cursor, Claude Code, Codex, Pi, and OpenCode.
+- Work from shells, CI, Cursor, Claude Code, Codex, and OpenCode.
 
 Compatible shells: [Fish](https://fishshell.com),
 [Bash](https://www.gnu.org/software/bash/), [Zsh](https://zsh.sourceforge.io).
@@ -277,7 +277,7 @@ putting secret values in the model context or chat transcript.
 
 ### Recommended usage: preTool hooks
 
-Cursor, Claude Code, Codex, Pi, and OpenCode can call `lade hook` before shell
+Cursor, Claude Code, Codex, and OpenCode can call `lade hook` before shell
 commands. When an agent runs a matching command, Lade rewrites it through
 `lade inject`, resolves the configured access, and redacts provider-resolved
 secret values from stdout and stderr.
@@ -346,32 +346,6 @@ untrusted hook or `[features].hooks = false` is a silent no-op. Global file:
           {
             "type": "command",
             "command": "lade hook --harness codex"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Pi (<code>.pi/settings.json</code>)</summary>
-
-Pi matches on `tool_name`, often lowercase `bash`. Global file:
-`~/.pi/agent/settings.json`.
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash|bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "lade hook --harness pi"
           }
         ]
       }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,10 @@ hooks, `lade inject`, file output, and MCP.
 
 ## 6. MCP
 
+`lade mcp` hydrates a server process. Every MCP `tools/call` that
+reaches `lade hook` is a verb row. Diary shapes are in
+[log.md](log.md).
+
 `lade mcp` uses the same rule matcher and binding resolver as command
 injection, but the output sink depends on the transport. A stdio target is
 spawned directly with public bindings in its environment. An HTTPS target is
@@ -223,7 +227,7 @@ detached provider PIDs on the T ticket so `lade unset` can stop them.
 Interactive prompts are forbidden in hook mode due to shell limitations (stdin hijacking, lack of echo). When a command matches a rule with a `disclaimer:`, the hook flow behaves as follows:
 
 1. **`lade set`** (preexec) detects the disclaimer.
-2. It outputs `unset` of leftover protocol keys (`LADE_PENDING`, `LADE_VIA`, `LADE_NETWORK_PIDS`, `LADE_DISCLAIMER_APPROVED`) so older shells clean up.
+2. It outputs `unset` of `LADE_RESTORE` so a previous snapshot cannot leak into the next set.
 3. It writes T with `pending: true` and outputs `export LADE_T=<id>`.
 4. It prints the disclaimer text in a single **Warning MessageBox** to stderr and exits with code 3 (`DISCLAIMER_WITHHELD`). It is not a loader failure, so no second error box is shown.
 5. The user's command runs **without secrets** (fail-closed).
@@ -261,7 +265,7 @@ and per-rule hydrate. It does not acquire network.
 
 The **pretool handler** (`src/pretool/`, invoked as `lade hook`) reads
 preToolUse JSON. Envelope comes from the payload first: `PreToolUse`
-and explicit Codex/Pi signals use `hookSpecificOutput` +
+and explicit Codex signals use `hookSpecificOutput` +
 `updatedInput`. Cursor's `updated_input` is only for `CURSOR_VERSION`
 or `preToolUse`. OpenCode's plugin sends `{ command, session_id }` and
 reads `{ command }` back. `CURSOR_VERSION` is last because Cursor also
@@ -278,11 +282,11 @@ window, not the T id. See [protocol.md](protocol.md).
 
 ### Installing preTool hooks (`src/pretool/install/`)
 
-`lade install` offers to wire `lade hook --harness <slug>` into agents present on the machine (`~/.cursor`, `~/.claude`, `~/.codex`, `~/.pi`, `~/.config/opencode`). The bin name follows argv[0]. OpenCode gets a native plugin at `~/.config/opencode/plugins/lade-pretool.js`. Project-local configs remain a copy-paste (README). `lade status` reports both global and project paths, plus whether the installed command is current. The daily version check also refreshes already-installed hook files. `lade upgrade` voids that stamp so the first run of the new binary refreshes them. `lade hook` rewrites matches with the same bin name and stores a free-form `agent` object on the diary row.
+`lade install` offers to wire `lade hook --harness <slug>` into agents present on the machine (`~/.cursor`, `~/.claude`, `~/.codex`, `~/.config/opencode`). The bin name follows argv[0]. OpenCode gets a native plugin at `~/.config/opencode/plugins/lade-pretool.js`. Project-local configs remain a copy-paste (README). `lade status` reports both global and project paths, plus whether the installed command is current. The daily version check also refreshes already-installed hook files and Lade-managed skills (content hash of the bundled `SKILL.md`). `lade upgrade` voids that stamp so the first run of the new binary refreshes them. `lade hook` rewrites shell matches with the same bin name and stores a free-form `agent` object on the diary row. MCP verbs are allow-only.
 
 ### Direct path
 
-When Via is not preexec or pretool (`lade inject`, `lade mcp`, `lade git …`), `detect()` promotes to organic if stdin and stderr are TTYs and no agent env signal fired. Otherwise Via stays unknown. `detect()` then uses env signals: `AI_AGENT` → `AGENT` → `CLAUDECODE=1` → `CURSOR_AGENT` → `COPILOT_MODEL`. `CURSOR_VERSION` is ignored because Cursor also sets it in human terminals. That classification selects `.when` rules and the fail-closed disclaimer wording. Codex isolation is the pretool rewrite (`--pretool`), not an audience env signal.
+When Via is not preexec, pretool, or mcp (`lade inject`, `lade git …`), `detect()` promotes to organic if stdin and stderr are TTYs and no agent env signal fired. Otherwise Via stays unknown. `lade mcp` is `Via::Mcp` / Agent. `detect()` then uses env signals: `AI_AGENT` → `AGENT` → `CLAUDECODE=1` → `CURSOR_AGENT` → `COPILOT_MODEL`. `CURSOR_VERSION` is ignored because Cursor also sets it in human terminals. That classification selects `.when` rules and the fail-closed disclaimer wording. Codex isolation is the pretool rewrite (`--pretool`), not an audience env signal.
 
 ### Exit codes
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,120 +5,98 @@ never stored. Vault addresses (`op://…`, `kubectl://…`) are.
 
 See also [architecture.md](architecture.md) and [protocol.md](protocol.md).
 
-## When a row is written
+## Turn it on
 
 `log:` is last-wins. Absent `log` is not a vote. `log: false` punches
-a hole.
+a hole on the rules it sits on.
+
+```yaml
+.:
+  .:
+    log: true
+"^git status":
+  .:
+    log: false
+```
+
+A child `^git status` with `log: false` silences only `git status`.
+It does not turn off `.: log: true` for `echo hi`.
 
 | Situation | Flag used |
 |---|---|
-| Command matched at least one rule | last explicit `log` on **those** rules |
-| No match at all | last explicit `log` on the **loaded walk** (`seen`) |
+| At least one rule matched | last explicit `log` on **those** rules |
+| No match | last explicit `log` on the **loaded walk** (`seen`) |
 
-A child `^git status` with `log: false` silences only `git status`.
-It does not turn off `.: log: true` for `echo hi` or `npm run deploy`.
+`LADE_EVENTS=off` skips writes. That is not `LADE_LOG` (`env_logger`).
+A write failure never changes the command's exit.
 
-| Surface | Writes |
+## What gets a row
+
+| Surface | Row |
 |---|---|
-| Pretool handler, no match | `seen` if walk `log` |
-| Pretool handler, match | no (wrap writes) |
-| Pretool wrap, inject, set, approve | `access` / `denied` / `seen` if the flag above is true |
-| Unset, eval, status, bench, log, usage, on, off | no |
-| MCP | no |
+| Shell wrap, inject, set, approve | `access` after hydrate, `denied` if a disclaimer is withheld, `seen` if nothing matched |
+| Pretool handler, no match | `seen` if the walk says `log` |
+| Pretool handler, match | no (the wrap writes) |
+| MCP `tools/call` (`lade hook`) | `seen` |
+| `lade mcp` (server start) | same as inject |
+| unset, eval, status, bench, log, usage, on, off | no |
 
-`lade set` and inject write after hydrate, before the child (or
-the naked shell command). An `unset` crash or a killed wrap still
-has the row. A disclaimer withhold is `denied`. Hydrate is
-`access`. Empty `matches` is `seen`.
+Starting an MCP server is not a hook. A row exists only if the
+process is `lade mcp -- …` (or a URL). Each later `tools/call` is a
+separate verb row, whether or not that prefix was used.
 
-Write failures never change the user command's exit. `LADE_EVENTS=off`
-skips writes. That is not `LADE_LOG` (`env_logger`).
+`via` is `preexec`, `pretool`, `mcp`, `organic`, or `unknown`.
+Audience is `human` or `agent`. Hydrate stays on the child. The diary
+only keeps the scrubbed `command`, `argv`, and public `matches`.
 
-## Store
+## Shape
 
-One global SQLite WAL:
-
-`ProjectDirs::from("com", "zifeo", "lade")` `data_local_dir()/events.db`
-
-Tests set `LADE_EVENTS_PATH`. `lade log --help` and `lade status`
-print the path. `status --json` keeps `ok` unchanged and adds `log`
-(`path`, `events`, raw `bytes` of db + wal + shm).
-
-```
-PRAGMA journal_mode = WAL;
-PRAGMA synchronous = NORMAL;
-PRAGMA busy_timeout = 250;
-```
-
-`BEGIN IMMEDIATE; INSERT; COMMIT`. Busy longer than 250 ms drops the
-row (`log::debug`). Schema migrates with `rusqlite_migration` on open.
-
-```sql
-CREATE TABLE events (
-  id TEXT PRIMARY KEY,
-  ts TEXT NOT NULL,
-  kind TEXT NOT NULL,
-  via TEXT,
-  audience TEXT,
-  actor TEXT,
-  repo TEXT,
-  git_commit TEXT,
-  command TEXT NOT NULL,
-  command_truncated INTEGER NOT NULL,
-  hydrate_ms REAL,
-  matches BLOB NOT NULL,
-  agent BLOB
-);
-```
-
-| Field | Meaning |
-|---|---|
-| `id` | uuid v7. Not the T ticket id |
-| `ts` | RFC3339 UTC, ms |
-| `kind` | `seen` / `access` / `denied` |
-| `via` | `preexec` / `pretool` / `organic` / `unknown` |
-| `audience` | `human` / `agent` |
-| `actor` | Lade user, else `$USER` / `$USERNAME` |
-| `repo` | Git root from `cwd`, or null. File reads under `.git/`, no `git` process |
-| `git_commit` | `HEAD` hex, or null |
-| `command` | Scrubbed text. Empty if a hydrated value is still a substring |
-| `command_truncated` | Cut at 1024 Unicode scalars |
-| `hydrate_ms` | Hydrate clock, `access` only |
-| `matches` | JSON array, overlay order |
-| `agent` | Free-form JSON (`harness`, `model`, `session`, later keys). Null if empty. Hook keys win over env. New keys do not need a schema change |
-
-`matches` example:
+`command` is argv0. `argv` is JSONB: a string array for a shell or
+`lade mcp` line, an object for an MCP verb. Each string is capped at
+1024 Unicode scalars. `command_truncated` is only the argv0 cap.
 
 ```json
-[
-  {
-    "file": "/proj/lade.yml",
-    "rule": "^npm run deploy",
-    "bindings": [
-      {"key": "API_TOKEN", "uri": "op://prod/api/credential"}
-    ]
-  }
-]
+{
+  "kind": "access",
+  "via": "pretool",
+  "command": "npm",
+  "argv": ["run", "deploy"],
+  "matches": [
+    {
+      "file": "/proj/lade.yml",
+      "rule": "^npm run deploy",
+      "bindings": [{ "key": "API_TOKEN", "uri": "op://prod/api/credential" }]
+    }
+  ]
+}
 ```
 
-Public keys only. `.NAME` is omitted. The URI is the `lade.yml`
-string, not a value.
+```json
+{
+  "kind": "seen",
+  "via": "mcp",
+  "command": "engram.mem_stats",
+  "argv": { "project": "lade" }
+}
+```
 
-## Scrub
+```json
+{
+  "kind": "access",
+  "via": "mcp",
+  "command": "engram",
+  "argv": ["--stdio"]
+}
+```
 
-Same pipeline on `seen`, `access`, and `denied`.
+`matches` lists public keys and their `lade.yml` URIs, not values.
+`.NAME` is omitted. `agent` is optional hook metadata (`harness`,
+`tool`, `session`, …). Keys may be absent.
 
-1. Strip leading `NAME=value` (`LADE_APPROVE=…`).
-2. On `access`, replace hydrated public values with `${NAME}`.
-3. If a hydrated value is still a substring, store `""` and stop.
-4. Cap at 1024 scalars.
-5. Context needles (`authorization:`, `bearer `, `x-api-key:`,
-   `access_token=`, …): replace the next credential run with `?`.
-6. Prefix keywords (`AKIA`, `sk-`, `ghp_`, `eyJ`, …).
-7. Tokens ≥ 20 scalars with a letter and a digit become `?`.
-
-Never store secret values, `.NAME`, `LADE_RESTORE`, child stdout, or
-`lade eval` output.
+Scrub: leading `NAME=value` is stripped, hydrated values become
+`${NAME}`, leftover hydrate stores `""`, then needles / prefixes /
+long tokens become `?`. Child stdout and `lade eval` are never
+stored.
 
 ## Read
 
@@ -130,21 +108,31 @@ default. Queries stay on the current git root (worktrees count).
 
 | Command | Meaning |
 |---|---|
-| `lade log` | Typed commands, newest first |
-| `lade log --group command` | Commands by frequency |
+| `lade log` | Newest first. Prints `command` plus `argv` |
+| `lade log --group command` | Frequency by argv0 |
 | `lade log --kind` / `--audience` | Filters |
-| `lade usage` | Matched `lade.yml` rules in this tree, most frequent first, with the file path |
+| `lade usage` | Matched `lade.yml` rules in this tree, most frequent first |
 | `lade log prune --keep` | The only delete |
-| `lade log share` | Gzipped SQLite snapshot (`lade-$USER-$FROM-$TO.tar.gz`) |
+| `lade log share` | Gzipped snapshot (`lade-$USER-$FROM-$TO.tar.gz`) |
 | `--source` | Read packs (or `local`) without writing the live db |
 | `--json` | Stored fields |
 
-`lade usage` is Lade usage, not a catalog. Unused rules and catch-all
-`.` are omitted. There is no npm / make / `scripts/` walk. `lade.yml`
-walk stops at `$HOME`. `lade log` and `lade usage` do not write rows.
+`lade usage` omits unused rules and catch-all `.`. The walk stops at
+`$HOME`. `lade log` and `lade usage` do not write rows.
 
-## T
+## Store
 
-The diary row is not the ticket. T is a 4-character tmp file used to
-run providers without a second YAML walk. The event `id` is a new
-uuid v7 at INSERT. See [protocol.md](protocol.md).
+One SQLite WAL:
+
+`ProjectDirs::from("com", "zifeo", "lade")` `data_local_dir()/events.db`
+
+`lade log --help` and `lade status` print the path. Tests set
+`LADE_EVENTS_PATH`. `status --json` adds `log` (`path`, `events`,
+`bytes`) and leaves `ok` unchanged.
+
+`matches`, `agent`, and `argv` are JSONB (`jsonb(...)` on write,
+`json(...)` on read). SQLite has no JSONB storage class, so
+`PRAGMA table_info` may show `BLOB`. The values are still JSONB.
+
+The diary row is not T. T is the 4-character tmp file used to run
+providers. See [protocol.md](protocol.md).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -38,7 +38,8 @@ The child never sees the id or `LADE_T`. Direct inject ignores a leftover
 | Preexec unset | `lade unset` | (none) |
 | Direct inject | `lade inject` / `lade <cmd>` | `organic` or `unknown` |
 | Approve | then inject | same as inject |
-| MCP | `lade mcp` | same as inject |
+| MCP spawn | `lade mcp` | `mcp` |
+| MCP verb | `lade hook` (no T) | `mcp` |
 | Eval URI | `lade eval <uri>` | (none) |
 
 ## Flow
@@ -104,7 +105,8 @@ No-match `seen` uses the last explicit `log` on the loaded walk.
 | Preexec unset | read pids | restore / pids / output files | yes, if `LADE_T` | no |
 | Direct inject | none | walk | | if match log, `seen` on no match |
 | Approve | read if `pending` | from file, then inject | wrap, after the child | if match log |
-| MCP | none | walk | | no |
+| MCP spawn | none | walk | | if match log, `seen` on no match |
+| MCP verb | none | no | | `seen` if match log or walk log |
 
 ## Disclaimer
 
@@ -154,13 +156,14 @@ not the row id.
 | `id` | uuid v7 |
 | `ts` | emit time |
 | `kind` | `access` / `denied` / `seen` |
-| `via` | `pretool` / `preexec` / `organic` / `unknown` |
+| `via` | `pretool` / `preexec` / `mcp` / `organic` / `unknown` |
 | `audience` | `human` / `agent` |
 | `actor` | same |
 | `repo` | `git_stamp(cwd)` |
 | `git_commit` | `git_stamp(cwd)` |
-| `command` | Scrubbed |
-| `command_truncated` | after the cap |
+| `command` | Scrubbed match/display text |
+| `command_truncated` | `command` cut at 1024 scalars |
+| `argv` | JSONB object or array, or null |
 | `hydrate_ms` | ms, or null |
 | `matches` | from the pre-event, or `[]` |
-| `agent` | Same object as the pre-event, or null |
+| `agent` | Sparse hook metadata, or null |

--- a/src/access.rs
+++ b/src/access.rs
@@ -21,6 +21,10 @@ pub struct AttachedAccess {
 }
 
 impl AttachedAccess {
+    pub fn public_hydrate(&self) -> HashMap<String, String> {
+        crate::inject::public_hydrate(&self.env, &self.files)
+    }
+
     pub fn cleanup(&mut self) -> Result<()> {
         remove_files(&mut self.files.keys())?;
         self.files.clear();

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -199,16 +199,19 @@ pub enum Command {
     Inject(InjectCommand),
     /// Resolve secrets for a local or remote MCP server.
     Mcp(McpCommand),
-    /// Set environment for shell.
+    /// Set environment for the interactive shell. Called by the preexec hook.
+    #[command(hide = true)]
     Set(EvalCommand),
-    /// Unset environment for shell.
+    /// Restore the shell environment. Called by the preexec hook.
+    #[command(hide = true)]
     Unset(EvalCommand),
     /// Evaluate a secret URI and print its resolved value.
     Eval {
         /// The secret URI to resolve (e.g., op://vault/item/field)
         uri: String,
     },
-    /// Handle preToolUse for Cursor, Claude Code, Codex, Pi, and OpenCode.
+    /// Handle agent preToolUse / MCP verb JSON on stdin. Called by the preTool hook.
+    #[command(hide = true)]
     Hook {
         /// Host that installed this hook. Unknown values are ignored.
         #[clap(long)]
@@ -246,9 +249,8 @@ pub struct Args {
     #[clap(short, long, value_parser, global = true)]
     pub help: bool,
 
-    /// Stamp this invocation as preTool. Wins over the subcommand. Via is
-    /// stored on the ticket, not on the child env.
-    #[clap(long, global = true, default_value_t = false)]
+    /// Stamp this invocation as preTool. Via is stored on the ticket, not the child env.
+    #[clap(long, global = true, default_value_t = false, hide = true)]
     pub pretool: bool,
 
     #[clap(subcommand)]
@@ -258,7 +260,13 @@ pub struct Args {
     pub verbose: Verbosity,
 }
 
-pub fn print_command_help(command: &Option<Command>, db_path: &Path) -> Result<()> {
+pub(super) const INTERNAL_HINT: &str = "Internal commands: lade --help -v";
+
+pub fn help_lists_internal(verbose: &Verbosity) -> bool {
+    verbose.log_level_filter() > log::LevelFilter::Error
+}
+
+pub fn print_command_help(command: &Option<Command>, db_path: &Path, verbose: bool) -> Result<()> {
     let mut cmd = Args::command();
     match command {
         Some(Command::Log(_)) => {
@@ -281,9 +289,34 @@ pub fn print_command_help(command: &Option<Command>, db_path: &Path) -> Result<(
                 return Ok(());
             }
         }
+        Some(Command::Set(_)) => return print_hidden_command(&mut cmd, "set"),
+        Some(Command::Unset(_)) => return print_hidden_command(&mut cmd, "unset"),
+        Some(Command::Hook { .. }) => return print_hidden_command(&mut cmd, "hook"),
         _ => {}
     }
+    if verbose {
+        reveal_internal(&mut cmd);
+    } else {
+        cmd = std::mem::take(&mut cmd).after_help(INTERNAL_HINT);
+    }
     cmd.print_help()?;
+    Ok(())
+}
+
+pub(super) fn reveal_internal(cmd: &mut clap::Command) {
+    for name in ["set", "unset", "hook"] {
+        if let Some(sub) = cmd.find_subcommand_mut(name) {
+            *sub = std::mem::take(sub).hide(false);
+        }
+    }
+    *cmd = std::mem::take(cmd).mut_arg("pretool", |arg| arg.hide(false));
+}
+
+fn print_hidden_command(cmd: &mut clap::Command, name: &str) -> Result<()> {
+    if let Some(sub) = cmd.find_subcommand_mut(name) {
+        *sub = std::mem::take(sub).hide(false);
+        sub.print_help()?;
+    }
     Ok(())
 }
 

--- a/src/args/tests.rs
+++ b/src/args/tests.rs
@@ -107,6 +107,44 @@ fn log_is_not_inject_alias() {
 }
 
 #[test]
+fn help_with_verbose_flag_lists_internal() {
+    let quiet = Args::try_parse_from(["lade", "--help"]).unwrap();
+    assert!(quiet.help);
+    assert!(!help_lists_internal(&quiet.verbose));
+    let short = Args::try_parse_from(["lade", "--help", "-v"]).unwrap();
+    assert!(short.help);
+    assert!(help_lists_internal(&short.verbose));
+    let long = Args::try_parse_from(["lade", "--help", "--verbose"]).unwrap();
+    assert!(long.help);
+    assert!(help_lists_internal(&long.verbose));
+}
+
+#[test]
+fn default_help_hides_internal_commands() {
+    let help = Args::command()
+        .after_help(super::INTERNAL_HINT)
+        .render_help()
+        .to_string();
+    assert!(help.contains("Internal commands: lade --help -v"));
+    assert!(!help.contains("\n  set "));
+    assert!(!help.contains("\n  unset "));
+    assert!(!help.contains("\n  hook "));
+    assert!(!help.contains("--pretool"));
+}
+
+#[test]
+fn verbose_help_lists_internal_commands() {
+    let mut cmd = Args::command();
+    super::reveal_internal(&mut cmd);
+    let help = cmd.render_help().to_string();
+    assert!(help.contains("  set "));
+    assert!(help.contains("  unset "));
+    assert!(help.contains("  hook "));
+    assert!(help.contains("--pretool"));
+    assert!(!help.contains("Internal commands: lade --help -v"));
+}
+
+#[test]
 fn usage_all_and_path_conflict() {
     assert!(Args::try_parse_from(["lade", "usage", "--all", "--path", "/tmp"]).is_err());
     let args = Args::try_parse_from(["lade", "usage", "--all"]).unwrap();

--- a/src/audience/mod.rs
+++ b/src/audience/mod.rs
@@ -16,6 +16,7 @@ use crate::config::Audience;
 pub enum Via {
     Preexec,
     Pretool,
+    Mcp,
     Organic,
     Unknown,
 }
@@ -23,13 +24,14 @@ pub enum Via {
 impl Via {
     pub const PREEXEC: &'static str = "preexec";
     pub const PRETOOL: &'static str = "pretool";
+    pub const MCP: &'static str = "mcp";
 
     /// Value stored on the ticket and in diary rows. Not written to child env.
     pub fn child_stamp(self) -> Option<&'static str> {
         match self {
             Via::Pretool => Some(Self::PRETOOL),
             Via::Preexec => Some(Self::PREEXEC),
-            Via::Organic | Via::Unknown => None,
+            Via::Mcp | Via::Organic | Via::Unknown => None,
         }
     }
 }
@@ -65,7 +67,7 @@ pub fn detect(
         other => other,
     };
     let audience = match via {
-        Via::Pretool => Audience::Agent,
+        Via::Pretool | Via::Mcp => Audience::Agent,
         Via::Preexec | Via::Organic => Audience::Human,
         Via::Unknown => {
             if agent_signal().is_some() {
@@ -94,6 +96,7 @@ fn via(command: &Command, pretool: bool) -> Via {
     match command {
         Command::Set(_) | Command::Unset(_) => Via::Preexec,
         Command::Hook { .. } => Via::Pretool,
+        Command::Mcp(_) => Via::Mcp,
         _ => Via::Unknown,
     }
 }

--- a/src/audience/tests.rs
+++ b/src/audience/tests.rs
@@ -42,6 +42,25 @@ fn set_cmd() -> Command {
 }
 
 #[test]
+fn mcp_command_is_mcp_agent() {
+    temp_env::with_vars(cleared_signals(), || {
+        let d = detect(
+            &Command::Mcp(crate::args::McpCommand {
+                url: None,
+                argv: vec!["env".into()],
+            }),
+            false,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(d.via, Via::Mcp);
+        assert_eq!(d.audience, Audience::Agent);
+        assert_eq!(d.ui, UiMode::Quiet);
+    });
+}
+
+#[test]
 fn leftover_via_env_does_not_classify() {
     temp_env::with_vars(
         cleared_signals()
@@ -230,4 +249,5 @@ fn child_stamp_matches_via() {
     assert_eq!(Via::Preexec.child_stamp(), Some(Via::PREEXEC));
     assert_eq!(Via::Organic.child_stamp(), None);
     assert_eq!(Via::Unknown.child_stamp(), None);
+    assert_eq!(Via::Mcp.child_stamp(), None);
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -159,6 +159,7 @@ mod tests {
             git_commit: None,
             command: command.into(),
             command_truncated: false,
+            argv: None,
             hydrate_ms: None,
             matches: match rule {
                 Some((file, r)) => json!([{

--- a/src/event/db.rs
+++ b/src/event/db.rs
@@ -6,10 +6,14 @@ use rusqlite::{Connection, OptionalExtension, params};
 use rusqlite_migration::{M, Migrations};
 use serde_json::{Value, json};
 
-use super::{BUSY_MS, EVENTS_AGENT_DDL, EVENTS_DDL, Event, LogInfo, db_path};
+use super::{BUSY_MS, EVENTS_AGENT_DDL, EVENTS_ARGV_DDL, EVENTS_DDL, Event, LogInfo, db_path};
 
 fn migrations() -> Migrations<'static> {
-    Migrations::new(vec![M::up(EVENTS_DDL), M::up(EVENTS_AGENT_DDL)])
+    Migrations::new(vec![
+        M::up(EVENTS_DDL),
+        M::up(EVENTS_AGENT_DDL),
+        M::up(EVENTS_ARGV_DDL),
+    ])
 }
 
 pub fn open() -> rusqlite::Result<Connection> {
@@ -38,7 +42,8 @@ pub fn query(
     let conn = open()?;
     let mut sql = String::from(
         "SELECT id, ts, kind, via, audience, actor, repo, git_commit,
-                command, command_truncated, hydrate_ms, json(matches), json(agent)
+                command, command_truncated, hydrate_ms, json(matches), json(agent),
+                json(argv)
          FROM events WHERE 1=1",
     );
     if since.is_some() {
@@ -97,12 +102,8 @@ pub fn query(
 pub(crate) fn event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
     let matches_raw: String = row.get(11)?;
     let matches = serde_json::from_str(&matches_raw).unwrap_or(json!([]));
-    let agent = row
-        .get::<_, Option<String>>(12)
-        .ok()
-        .flatten()
-        .and_then(|raw| serde_json::from_str(&raw).ok())
-        .filter(|value: &Value| !value.is_null());
+    let agent = json_col(row, 12);
+    let argv = json_col(row, 13);
     Ok(Event {
         id: row.get(0)?,
         ts: row.get(1)?,
@@ -114,10 +115,19 @@ pub(crate) fn event_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event>
         git_commit: row.get(7)?,
         command: row.get(8)?,
         command_truncated: row.get::<_, i64>(9)? != 0,
+        argv,
         hydrate_ms: row.get(10)?,
         matches,
         agent,
     })
+}
+
+fn json_col(row: &rusqlite::Row<'_>, idx: usize) -> Option<Value> {
+    row.get::<_, Option<String>>(idx)
+        .ok()
+        .flatten()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .filter(|value: &Value| !value.is_null())
 }
 
 pub fn prune_before(ts: &DateTime<Utc>) -> rusqlite::Result<usize> {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -18,6 +18,7 @@ pub use git::git_stamp;
 #[allow(unused_imports)]
 pub use write::emit;
 pub use write::emit_if;
+pub use write::emit_verb;
 
 pub(crate) use db::event_from_row;
 
@@ -43,8 +44,10 @@ pub(crate) const EVENTS_DDL: &str = "CREATE TABLE events (
 
 pub(crate) const EVENTS_AGENT_DDL: &str = "ALTER TABLE events ADD COLUMN agent BLOB";
 
+pub(crate) const EVENTS_ARGV_DDL: &str = "ALTER TABLE events ADD COLUMN argv JSONB";
+
 pub(crate) fn events_ddl() -> String {
-    format!("{EVENTS_DDL}{EVENTS_AGENT_DDL};")
+    format!("{EVENTS_DDL}{EVENTS_AGENT_DDL};{EVENTS_ARGV_DDL};")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +79,8 @@ pub struct Event {
     pub git_commit: Option<String>,
     pub command: String,
     pub command_truncated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argv: Option<Value>,
     pub hydrate_ms: Option<f64>,
     pub matches: Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -132,6 +137,26 @@ pub fn match_tree_from(
     Value::Array(out)
 }
 
+pub fn display_line(command: &str, argv: Option<&Value>) -> Option<String> {
+    if command.is_empty() {
+        return None;
+    }
+    match argv {
+        Some(Value::Array(items)) if !items.is_empty() => {
+            let rest: Vec<&str> = items.iter().filter_map(Value::as_str).collect();
+            if rest.is_empty() {
+                Some(command.to_string())
+            } else {
+                Some(format!("{} {}", command, rest.join(" ")))
+            }
+        }
+        Some(Value::Object(map)) if !map.is_empty() => {
+            Some(format!("{} {}", command, Value::Object(map.clone())))
+        }
+        _ => Some(command.to_string()),
+    }
+}
+
 pub fn logged_kind(matches: &Value) -> Kind {
     match matches.as_array() {
         Some(items) if !items.is_empty() => Kind::Access,
@@ -146,6 +171,7 @@ pub struct Emit {
     pub actor: Option<String>,
     pub cwd: PathBuf,
     pub command: String,
+    pub argv: Option<Value>,
     pub hydrated: Option<HashMap<String, String>>,
     pub matches: Value,
     pub hydrate_ms: Option<f64>,

--- a/src/event/tests.rs
+++ b/src/event/tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::audience::Via;
+use crate::config::Audience;
+use serde_json::{Value, json};
+use std::path::PathBuf;
 
 #[test]
 fn db_path_override_and_project_dirs() {
@@ -46,4 +50,127 @@ fn git_stamp_treats_gitfile_as_worktree_root() {
         commit.as_deref(),
         Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     );
+}
+
+fn verb_emit(command: &str, argv: Option<Value>, agent: Value) -> Emit {
+    Emit {
+        kind: Kind::Seen,
+        via: Via::Mcp,
+        audience: Audience::Agent,
+        actor: None,
+        cwd: PathBuf::from("."),
+        command: command.into(),
+        argv,
+        hydrated: None,
+        matches: json!([]),
+        hydrate_ms: None,
+        agent: Some(agent),
+    }
+}
+
+#[test]
+fn before_mcp_then_pretool_is_one_filled_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.db");
+    temp_env::with_var("LADE_EVENTS_PATH", Some(path.to_str().unwrap()), || {
+        emit_verb(
+            true,
+            Some("beforeMCPExecution"),
+            Some("toolu_1"),
+            verb_emit(
+                "engram.mem_stats",
+                None,
+                json!({
+                    "tool_use_id": "toolu_1",
+                    "hook": "beforeMCPExecution",
+                    "launch": "engram"
+                }),
+            ),
+        );
+        emit_verb(
+            true,
+            Some("preToolUse"),
+            Some("toolu_1"),
+            verb_emit(
+                "engram.mem_stats",
+                Some(json!({"project": "lade"})),
+                json!({
+                    "tool_use_id": "toolu_1",
+                    "hook": "preToolUse",
+                    "tool": "mem_stats"
+                }),
+            ),
+        );
+        let rows = query(None, None, None, None, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].command, "engram.mem_stats");
+        assert_eq!(rows[0].argv, Some(json!({"project": "lade"})));
+        let agent = rows[0].agent.as_ref().unwrap();
+        assert_eq!(agent["launch"], "engram");
+        assert_eq!(agent["hook"], "preToolUse");
+        assert_eq!(agent["tool"], "mem_stats");
+    });
+}
+
+#[test]
+fn pretool_then_before_mcp_patches_launch() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.db");
+    temp_env::with_var("LADE_EVENTS_PATH", Some(path.to_str().unwrap()), || {
+        emit_verb(
+            true,
+            Some("preToolUse"),
+            Some("toolu_2"),
+            verb_emit(
+                "engram.mem_stats",
+                Some(json!({"project": "lade"})),
+                json!({"tool_use_id": "toolu_2", "hook": "preToolUse"}),
+            ),
+        );
+        emit_verb(
+            true,
+            Some("beforeMCPExecution"),
+            Some("toolu_2"),
+            verb_emit(
+                "engram.mem_stats",
+                None,
+                json!({
+                    "tool_use_id": "toolu_2",
+                    "hook": "beforeMCPExecution",
+                    "launch": "engram"
+                }),
+            ),
+        );
+        let rows = query(None, None, None, None, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].argv, Some(json!({"project": "lade"})));
+        assert_eq!(rows[0].agent.as_ref().unwrap()["launch"], "engram");
+    });
+}
+
+#[test]
+fn launch_only_before_mcp_writes_a_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.db");
+    temp_env::with_var("LADE_EVENTS_PATH", Some(path.to_str().unwrap()), || {
+        emit_verb(
+            true,
+            Some("beforeMCPExecution"),
+            Some("toolu_3"),
+            verb_emit(
+                "",
+                None,
+                json!({
+                    "tool_use_id": "toolu_3",
+                    "hook": "beforeMCPExecution",
+                    "launch": "engram"
+                }),
+            ),
+        );
+        let rows = query(None, None, None, None, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].command, "");
+        assert_eq!(rows[0].via.as_deref(), Some("mcp"));
+        assert_eq!(rows[0].agent.as_ref().unwrap()["launch"], "engram");
+    });
 }

--- a/src/event/write.rs
+++ b/src/event/write.rs
@@ -1,5 +1,6 @@
 use chrono::{SecondsFormat, Utc};
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
+use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::audience::Via;
@@ -20,8 +21,159 @@ pub fn emit_if(log: bool, e: Emit) {
     }
 }
 
+pub fn emit_verb(log: bool, hook: Option<&str>, tool_use_id: Option<&str>, e: Emit) {
+    if !log {
+        return;
+    }
+    if let Err(err) = emit_verb_inner(hook, tool_use_id, e) {
+        log::debug!("lade event write failed: {err}");
+    }
+}
+
+fn emit_verb_inner(hook: Option<&str>, tool_use_id: Option<&str>, e: Emit) -> rusqlite::Result<()> {
+    let Some(id) = tool_use_id.filter(|id| !id.is_empty()) else {
+        emit_inner(e)?;
+        return Ok(());
+    };
+    let mut conn = super::open()?;
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let existing: Option<(String, String, Option<String>, Option<String>)> = tx
+        .query_row(
+            "SELECT id, command, json(agent), json(argv) FROM events
+             WHERE json_extract(agent, '$.tool_use_id') = ?1
+             ORDER BY ts DESC LIMIT 1",
+            rusqlite::params![id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()?;
+    match existing {
+        Some((event_id, _, raw, _)) if hook == Some("beforeMCPExecution") => {
+            let agent = merge_launch(raw, e.agent.as_ref());
+            let encoded = serde_json::to_string(&agent).unwrap_or_else(|_| "null".into());
+            tx.execute(
+                "UPDATE events SET agent = jsonb(?2) WHERE id = ?1",
+                rusqlite::params![event_id, encoded],
+            )?;
+            tx.commit()?;
+        }
+        Some((event_id, command, raw, argv)) if hook == Some("preToolUse") => {
+            if command.is_empty() || json_missing(&argv) {
+                fill_verb_row(
+                    &tx,
+                    &event_id,
+                    raw,
+                    command.is_empty(),
+                    json_missing(&argv),
+                    e,
+                )?;
+                tx.commit()?;
+            }
+        }
+        Some(_) => {}
+        None => {
+            drop(tx);
+            emit_inner(e)?;
+        }
+    }
+    Ok(())
+}
+
+fn json_missing(raw: &Option<String>) -> bool {
+    match raw.as_deref() {
+        None | Some("null") | Some("") => true,
+        Some(value) => serde_json::from_str::<Value>(value)
+            .ok()
+            .is_none_or(|parsed| parsed.is_null()),
+    }
+}
+
+fn merge_launch(raw: Option<String>, patch: Option<&Value>) -> Value {
+    let mut agent: Value = raw
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(json!({}));
+    if let Some(patch) = patch.and_then(Value::as_object)
+        && let Some(obj) = agent.as_object_mut()
+    {
+        if let Some(launch) = patch.get("launch") {
+            obj.insert("launch".to_string(), launch.clone());
+        }
+        if let Some(hook_name) = patch.get("hook") {
+            obj.insert("hook".to_string(), hook_name.clone());
+        }
+    }
+    agent
+}
+
+fn fill_verb_row(
+    tx: &rusqlite::Transaction<'_>,
+    event_id: &str,
+    raw_agent: Option<String>,
+    fill_command: bool,
+    fill_argv: bool,
+    e: Emit,
+) -> rusqlite::Result<()> {
+    let redacted = scrub::redact_command(&e.command, None);
+    let (command, truncated) = scrub::cap_text(redacted.command);
+    let argv = scrub::redact_argv(e.argv, None);
+    let mut agent: Value = raw_agent
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(json!({}));
+    if let Some(patch) = e.agent.as_ref().and_then(Value::as_object)
+        && let Some(obj) = agent.as_object_mut()
+    {
+        for (key, value) in patch {
+            if key == "launch" && obj.contains_key("launch") {
+                continue;
+            }
+            obj.insert(key.clone(), value.clone());
+        }
+    }
+    let encoded_agent = serde_json::to_string(&agent).unwrap_or_else(|_| "null".into());
+    let encoded_argv = argv
+        .as_ref()
+        .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "null".into()));
+    let matches = serde_json::to_string(&e.matches).unwrap_or_else(|_| "[]".into());
+    if fill_command && fill_argv {
+        tx.execute(
+            "UPDATE events SET command = ?2, command_truncated = ?3, argv = jsonb(?4),
+                matches = jsonb(?5), agent = jsonb(?6)
+             WHERE id = ?1",
+            rusqlite::params![
+                event_id,
+                command,
+                truncated as i64,
+                encoded_argv,
+                matches,
+                encoded_agent
+            ],
+        )?;
+    } else if fill_command {
+        tx.execute(
+            "UPDATE events SET command = ?2, command_truncated = ?3, matches = jsonb(?4),
+                agent = jsonb(?5)
+             WHERE id = ?1",
+            rusqlite::params![event_id, command, truncated as i64, matches, encoded_agent],
+        )?;
+    } else {
+        tx.execute(
+            "UPDATE events SET argv = jsonb(?2), matches = jsonb(?3), agent = jsonb(?4)
+             WHERE id = ?1",
+            rusqlite::params![event_id, encoded_argv, matches, encoded_agent],
+        )?;
+    }
+    Ok(())
+}
+
 fn emit_inner(e: Emit) -> rusqlite::Result<()> {
     let redacted = scrub::redact_command(&e.command, e.hydrated.as_ref());
+    let (command, argv) = if e.argv.is_none() {
+        scrub::peel_command(&redacted.command)
+    } else {
+        (redacted.command, e.argv)
+    };
+    let (command, truncated) = scrub::cap_text(command);
     let (repo, git_commit) = git_stamp(&e.cwd);
     let event = Event {
         id: Uuid::now_v7().to_string(),
@@ -31,6 +183,7 @@ fn emit_inner(e: Emit) -> rusqlite::Result<()> {
             match e.via {
                 Via::Preexec => "preexec",
                 Via::Pretool => "pretool",
+                Via::Mcp => Via::MCP,
                 Via::Organic => "organic",
                 Via::Unknown => "unknown",
             }
@@ -46,8 +199,9 @@ fn emit_inner(e: Emit) -> rusqlite::Result<()> {
         actor: e.actor,
         repo,
         git_commit,
-        command: redacted.command,
-        command_truncated: redacted.truncated,
+        command,
+        command_truncated: truncated,
+        argv: scrub::redact_argv(argv, e.hydrated.as_ref()),
         hydrate_ms: e.hydrate_ms,
         matches: e.matches,
         agent: e.agent.filter(|value| !value.is_null()),
@@ -59,11 +213,15 @@ fn emit_inner(e: Emit) -> rusqlite::Result<()> {
         .agent
         .as_ref()
         .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "null".into()));
+    let argv = event
+        .argv
+        .as_ref()
+        .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "null".into()));
     tx.execute(
         "INSERT INTO events (
             id, ts, kind, via, audience, actor, repo, git_commit,
-            command, command_truncated, hydrate_ms, matches, agent
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, jsonb(?12), jsonb(?13))",
+            command, command_truncated, hydrate_ms, matches, agent, argv
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, jsonb(?12), jsonb(?13), jsonb(?14))",
         params![
             event.id,
             event.ts,
@@ -78,6 +236,7 @@ fn emit_inner(e: Emit) -> rusqlite::Result<()> {
             event.hydrate_ms,
             matches,
             agent,
+            argv,
         ],
     )?;
     tx.commit()

--- a/src/inject/mod.rs
+++ b/src/inject/mod.rs
@@ -188,12 +188,13 @@ pub(super) async fn resolve_provider_work(
     )?)))
 }
 
-pub(super) fn emit_seen_if_walk_log(
+pub(crate) fn emit_seen_if_walk_log(
     config: &Config,
     ctx: &InvocationContext,
     command: &str,
     current_dir: &Path,
     saved_user: &Option<String>,
+    argv: Option<serde_json::Value>,
 ) {
     if !config.log_on_walk() {
         return;
@@ -207,6 +208,7 @@ pub(super) fn emit_seen_if_walk_log(
             actor: event::actor(saved_user),
             cwd: current_dir.to_path_buf(),
             command: command.to_string(),
+            argv,
             hydrated: None,
             matches: json!([]),
             hydrate_ms: None,
@@ -215,7 +217,7 @@ pub(super) fn emit_seen_if_walk_log(
     );
 }
 
-pub(super) fn public_hydrate(
+pub(crate) fn public_hydrate(
     env: &HashMap<String, String>,
     files: &HashMap<PathBuf, HashMap<String, String>>,
 ) -> HashMap<String, String> {
@@ -231,8 +233,6 @@ pub(super) fn public_hydrate(
         if key.starts_with('.')
             || key == crate::shell::LADE_VIA
             || key == crate::shell::LADE_RESTORE
-            || key == crate::shell::LADE_NETWORK_PIDS
-            || key == crate::shell::LADE_PENDING
             || key == crate::shell::LADE_T
         {
             continue;

--- a/src/inject/run.rs
+++ b/src/inject/run.rs
@@ -51,7 +51,7 @@ pub async fn run_inject(
     let work = match work {
         Some(work) => work,
         None => {
-            emit_seen_if_walk_log(config, ctx, &command, current_dir, &saved_user);
+            emit_seen_if_walk_log(config, ctx, &command, current_dir, &saved_user, None);
             return run_command_without_providers(&command, &opts, ctx, shell, current_dir);
         }
     };
@@ -67,6 +67,7 @@ pub async fn run_inject(
                     actor: event::actor(&saved_user),
                     cwd: current_dir.to_path_buf(),
                     command: command.clone(),
+                    argv: None,
                     hydrated: None,
                     matches: work.matches.clone(),
                     hydrate_ms: None,
@@ -129,6 +130,7 @@ pub async fn run_inject(
             actor: event::actor(&saved_user),
             cwd: current_dir.to_path_buf(),
             command: command.clone(),
+            argv: None,
             hydrated,
             matches: work.matches,
             hydrate_ms,

--- a/src/inject/set.rs
+++ b/src/inject/set.rs
@@ -23,12 +23,10 @@ pub async fn handle_set(
     commands: Vec<String>,
     current_dir: PathBuf,
 ) -> Result<()> {
-    let mut stale: Vec<String> = crate::shell::STALE_UNSET
-        .iter()
-        .map(|key| (*key).to_string())
-        .collect();
-    stale.push(crate::shell::LADE_RESTORE.to_string());
-    println!("{}", shell.unset(stale));
+    println!(
+        "{}",
+        shell.unset(vec![crate::shell::LADE_RESTORE.to_string()])
+    );
     let command = commands.join(" ");
     let use_ticket = ticket_ready(ctx.ticket_id.as_deref());
     let saved_user = crate::config::saved_user().await?;
@@ -44,7 +42,7 @@ pub async fn handle_set(
     let work = match work {
         Some(work) => work,
         None => {
-            emit_seen_if_walk_log(config, ctx, &command, &current_dir, &saved_user);
+            emit_seen_if_walk_log(config, ctx, &command, &current_dir, &saved_user, None);
             println!("{}", shell.set(HashMap::new()));
             return Ok(());
         }
@@ -71,6 +69,7 @@ pub async fn handle_set(
                     actor: event::actor(&saved_user),
                     cwd: current_dir.clone(),
                     command: command.clone(),
+                    argv: None,
                     hydrated: None,
                     matches: work.matches.clone(),
                     hydrate_ms: None,
@@ -116,6 +115,7 @@ pub async fn handle_set(
             actor: event::actor(&saved_user),
             cwd: current_dir.clone(),
             command: command.clone(),
+            argv: None,
             hydrated: Some(public_hydrate(&env, &files)),
             matches: work.matches,
             hydrate_ms: Some(hydrate_started.elapsed().as_secs_f64() * 1000.0),

--- a/src/inject/unset.rs
+++ b/src/inject/unset.rs
@@ -50,9 +50,6 @@ pub async fn handle_unset(
         }
         let _ = ticket::unlink(id);
     }
-    if let Ok(raw) = std::env::var(crate::shell::LADE_NETWORK_PIDS) {
-        network::stop_network_pids(&raw);
-    }
     remove_files(&mut files.keys())?;
     let restore = match std::env::var(crate::shell::LADE_RESTORE) {
         Err(_) => None,
@@ -70,12 +67,10 @@ pub async fn handle_unset(
     let env_line = restore
         .map(|payload| shell.restore(payload.env))
         .unwrap_or_default();
-    let mut unset_keys: Vec<String> = crate::shell::STALE_UNSET
-        .iter()
-        .map(|key| (*key).to_string())
-        .collect();
-    unset_keys.push(crate::shell::LADE_RESTORE.to_string());
-    unset_keys.push(crate::shell::LADE_T.to_string());
+    let unset_keys = vec![
+        crate::shell::LADE_RESTORE.to_string(),
+        crate::shell::LADE_T.to_string(),
+    ];
     let meta = shell.unset(unset_keys);
     let line = [env_line, meta]
         .into_iter()

--- a/src/log_cmd/log.rs
+++ b/src/log_cmd/log.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use super::{fetch_events, filter_opt, query_window, repo_filter};
 use crate::args::{LogAction, LogCommand};
 use crate::catalog;
-use crate::event;
+use crate::event::{self, Event};
 use crate::log_pack;
 use crate::message_box;
 use crate::window;
@@ -83,11 +83,22 @@ pub fn run_log(opts: LogCommand, agent: bool) -> Result<()> {
                 row.ts,
                 row.kind,
                 row.via.as_deref().unwrap_or("-"),
-                row.command
+                log_command(&row)
             );
         }
     }
     Ok(())
+}
+
+fn log_command(row: &Event) -> String {
+    crate::event::display_line(&row.command, row.argv.as_ref()).unwrap_or_else(|| {
+        row.agent
+            .as_ref()
+            .and_then(|agent| agent.get("launch"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("-")
+            .to_string()
+    })
 }
 
 fn run_share(opts: &LogCommand, agent: bool, output: Option<PathBuf>) -> Result<()> {

--- a/src/log_pack/share.rs
+++ b/src/log_pack/share.rs
@@ -38,7 +38,7 @@ pub fn share(
     };
     let to_label = compact_utc(to_ts);
     let manifest = json!({
-        "v": 1,
+        "v": 2,
         "exported_at": now.to_rfc3339_opts(SecondsFormat::Millis, true),
         "since": since
             .map(|ts| ts.to_rfc3339_opts(SecondsFormat::Millis, true))
@@ -87,11 +87,15 @@ fn write_snapshot_db(events: &[Event], path: &Path) -> Result<()> {
             .agent
             .as_ref()
             .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "null".into()));
+        let argv = event
+            .argv
+            .as_ref()
+            .map(|value| serde_json::to_string(value).unwrap_or_else(|_| "null".into()));
         conn.execute(
             "INSERT INTO events (
                 id, ts, kind, via, audience, actor, repo, git_commit,
-                command, command_truncated, hydrate_ms, matches, agent
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, jsonb(?12), jsonb(?13))",
+                command, command_truncated, hydrate_ms, matches, agent, argv
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, jsonb(?12), jsonb(?13), jsonb(?14))",
             params![
                 event.id,
                 event.ts,
@@ -106,6 +110,7 @@ fn write_snapshot_db(events: &[Event], path: &Path) -> Result<()> {
                 event.hydrate_ms,
                 matches,
                 agent,
+                argv,
             ],
         )?;
     }
@@ -127,7 +132,7 @@ fn write_tar_gz(out: &Path, manifest: &Path, events_db: &Path) -> Result<()> {
 }
 
 pub(super) fn redact_for_share(event: &Event, home: &Path) -> Option<Event> {
-    if event.command.is_empty() {
+    if event.command.is_empty() && event.via.as_deref() != Some("mcp") {
         return None;
     }
     let git_root = event.repo.as_deref();
@@ -145,6 +150,7 @@ pub(super) fn redact_for_share(event: &Event, home: &Path) -> Option<Event> {
         git_commit: event.git_commit.clone(),
         command,
         command_truncated: event.command_truncated,
+        argv: event.argv.clone(),
         hydrate_ms: event.hydrate_ms,
         matches,
         agent: event.agent.clone(),

--- a/src/log_pack/source.rs
+++ b/src/log_pack/source.rs
@@ -154,13 +154,17 @@ pub(super) fn query_attached(
         .enumerate()
         .map(|(idx, _)| {
             let alias = format!("p{idx}");
-            attached_events_select(&alias, attached_has_agent(&conn, &alias))
+            attached_events_select(
+                &alias,
+                attached_has_column(&conn, &alias, "agent"),
+                attached_has_column(&conn, &alias, "argv"),
+            )
         })
         .collect::<Vec<_>>()
         .join(" UNION ALL ");
     let mut sql = format!(
         "SELECT id, ts, kind, via, audience, actor, repo, git_commit,
-                command, command_truncated, hydrate_ms, matches, agent
+                command, command_truncated, hydrate_ms, matches, agent, argv
          FROM ({union}) WHERE 1=1"
     );
     if since.is_some() {
@@ -217,7 +221,7 @@ pub(super) fn query_attached(
     Ok(out)
 }
 
-fn attached_has_agent(conn: &Connection, alias: &str) -> bool {
+fn attached_has_column(conn: &Connection, alias: &str, column: &str) -> bool {
     let sql = format!("PRAGMA {alias}.table_info(events)");
     let Ok(mut stmt) = conn.prepare(&sql) else {
         return false;
@@ -229,22 +233,28 @@ fn attached_has_agent(conn: &Connection, alias: &str) -> bool {
         let Ok(name) = row.get::<_, String>(1) else {
             continue;
         };
-        if name == "agent" {
+        if name == column {
             return true;
         }
     }
     false
 }
 
-fn attached_events_select(alias: &str, has_agent: bool) -> String {
+fn attached_events_select(alias: &str, has_agent: bool, has_argv: bool) -> String {
     let agent = if has_agent {
         "json(agent) AS agent".to_string()
     } else {
         "NULL AS agent".to_string()
     };
+    let argv = if has_argv {
+        "json(argv) AS argv".to_string()
+    } else {
+        "NULL AS argv".to_string()
+    };
     format!(
         "SELECT id, ts, kind, via, audience, actor, repo, git_commit,
-                command, command_truncated, hydrate_ms, json(matches) AS matches, {agent}
+                command, command_truncated, hydrate_ms, json(matches) AS matches,
+                {agent}, {argv}
          FROM {alias}.events"
     )
 }

--- a/src/log_pack/tests.rs
+++ b/src/log_pack/tests.rs
@@ -34,6 +34,7 @@ fn redact_strips_home_and_git_root_prefixes() {
         git_commit: None,
         command: "/Users/me/proj/bin/deploy".into(),
         command_truncated: false,
+        argv: None,
         hydrate_ms: None,
         matches: json!([]),
         agent: Some(json!({"harness": "cursor"})),
@@ -54,6 +55,7 @@ fn redact_strips_home_and_git_root_prefixes() {
         git_commit: event.git_commit,
         command: "/Users/me/bin/deploy".into(),
         command_truncated: false,
+        argv: None,
         hydrate_ms: None,
         matches: json!([]),
         agent: event.agent.clone(),
@@ -61,6 +63,30 @@ fn redact_strips_home_and_git_root_prefixes() {
     let out = redact_for_share(&home_first, Path::new("/Users/me")).unwrap();
     assert_eq!(out.command, "bin/deploy");
     assert_eq!(out.agent, Some(json!({"harness": "cursor"})));
+}
+
+#[test]
+fn share_keeps_empty_mcp_command() {
+    let event = Event {
+        id: "1".into(),
+        ts: "2026-09-05T00:00:00.000Z".into(),
+        kind: "seen".into(),
+        via: Some("mcp".into()),
+        audience: Some("agent".into()),
+        actor: Some("alice".into()),
+        repo: None,
+        git_commit: None,
+        command: String::new(),
+        command_truncated: false,
+        argv: None,
+        hydrate_ms: None,
+        matches: json!([]),
+        agent: Some(json!({"launch": "engram", "hook": "beforeMCPExecution"})),
+    };
+    let out = redact_for_share(&event, Path::new("/Users/me")).unwrap();
+    assert_eq!(out.command, "");
+    assert_eq!(out.via.as_deref(), Some("mcp"));
+    assert_eq!(out.agent.unwrap()["launch"], "engram");
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,11 @@ async fn run() -> Result<()> {
     }
 
     if args.help {
-        args::print_command_help(&args.command, &event::db_path())?;
+        args::print_command_help(
+            &args.command,
+            &event::db_path(),
+            args::help_lists_internal(&args.verbose),
+        )?;
         return Ok(());
     }
 
@@ -93,7 +97,7 @@ async fn run() -> Result<()> {
         }),
         Some(command) => command,
         None => {
-            args::print_command_help(&None, &event::db_path())?;
+            args::print_command_help(&None, &event::db_path(), false)?;
             return Ok(());
         }
     };

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -2,10 +2,12 @@ use std::{collections::HashMap, ffi::OsString, path::Path};
 
 use anyhow::{Result, bail};
 use log::info;
+use serde_json::{Value, json};
 use url::Url;
 
 use crate::{
-    args::McpCommand, config::Config, context::InvocationContext, message_box::MessageBox, prompt,
+    args::McpCommand, config::Config, context::InvocationContext, event, inject,
+    message_box::MessageBox, prompt,
 };
 
 mod stdio;
@@ -27,15 +29,70 @@ pub async fn run(
     current_dir: &Path,
 ) -> Result<Option<i32>> {
     let target = target(&command)?;
-    let rules = config.collect_for(&target, ctx.audience);
+    let stored = spawn_command(&command);
+    let argv = spawn_argv(&command);
+    let patterned = config.collect_for_with_pattern(&target, ctx.audience);
+    let rules = patterned
+        .iter()
+        .map(|(path, _, rule)| (path.clone(), rule.clone()))
+        .collect::<Vec<_>>();
+    let saved_user = crate::config::saved_user().await?;
+    let work = if patterned.is_empty() {
+        None
+    } else {
+        Some(Config::pre_event_work(&patterned, &saved_user)?)
+    };
     let disclaimers = Config::disclaimers_from_rules(&rules);
-    prompt::resolve_disclaimers(ctx, &disclaimers, &target).await?;
+    if let Err(e) = prompt::resolve_disclaimers(ctx, &disclaimers, &target).await {
+        if e.downcast_ref::<prompt::DisclaimerWithheld>().is_some()
+            && let Some(work) = &work
+        {
+            event::emit_if(
+                work.log,
+                event::Emit {
+                    kind: event::Kind::Denied,
+                    via: ctx.via,
+                    audience: ctx.audience,
+                    actor: event::actor(&saved_user),
+                    cwd: current_dir.to_path_buf(),
+                    command: stored.clone(),
+                    argv: argv.clone(),
+                    hydrated: None,
+                    matches: work.matches.clone(),
+                    hydrate_ms: None,
+                    agent: crate::agent_meta::merge(serde_json::Value::Null),
+                },
+            );
+        }
+        return Err(e);
+    }
+    let hydrate_started = std::time::Instant::now();
     let mut access = crate::access::acquire_attached(
         config,
         &rules,
         ctx.stderr_is_terminal && !ctx.stdin_is_terminal,
     )
     .await?;
+    let hydrate_ms = Some(hydrate_started.elapsed().as_secs_f64() * 1000.0);
+    match &work {
+        Some(work) => event::emit_if(
+            work.log,
+            event::Emit {
+                kind: event::logged_kind(&work.matches),
+                via: ctx.via,
+                audience: ctx.audience,
+                actor: event::actor(&saved_user),
+                cwd: current_dir.to_path_buf(),
+                command: stored.clone(),
+                argv: argv.clone(),
+                hydrated: Some(access.public_hydrate()),
+                matches: work.matches.clone(),
+                hydrate_ms,
+                agent: crate::agent_meta::merge(serde_json::Value::Null),
+            },
+        ),
+        None => inject::emit_seen_if_walk_log(config, ctx, &stored, current_dir, &saved_user, argv),
+    }
     for warning in &access.warnings {
         MessageBox::new().warning().line(warning).print_stderr();
     }
@@ -56,6 +113,29 @@ pub async fn run(
     access.cleanup()?;
     info!("mcp stopped");
     result
+}
+
+fn spawn_command(command: &McpCommand) -> String {
+    if let Some(url) = &command.url {
+        return url.clone();
+    }
+    command
+        .argv
+        .first()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+fn spawn_argv(command: &McpCommand) -> Option<Value> {
+    if command.argv.len() < 2 {
+        return None;
+    }
+    Some(json!(
+        command.argv[1..]
+            .iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+    ))
 }
 
 fn target(command: &McpCommand) -> Result<String> {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,6 +5,6 @@ mod progress;
 mod types;
 
 pub use acquire::{start_attached_network_session, start_detached_network_session};
-pub use process::{stop_network_pids, stop_network_pids_list};
+pub use process::stop_network_pids_list;
 pub use progress::{ProviderProgressEvent, ProviderProgressKind, format_timing};
 pub use types::AcquiredNetwork;

--- a/src/network/process/mod.rs
+++ b/src/network/process/mod.rs
@@ -64,15 +64,6 @@ pub(crate) fn wait_child_ready(
     }
 }
 
-pub fn stop_network_pids(raw: &str) {
-    let pids = raw
-        .split(',')
-        .filter_map(|part| part.trim().parse::<i32>().ok())
-        .filter_map(|pid| u32::try_from(pid).ok())
-        .collect::<Vec<_>>();
-    stop_network_pids_list(&pids);
-}
-
 pub fn stop_network_pids_list(pids: &[u32]) {
     for pid in pids.iter().filter_map(|pid| i32::try_from(*pid).ok()) {
         match killpg(Pid::from_raw(pid), Signal::SIGTERM) {

--- a/src/pretool/install/config.rs
+++ b/src/pretool/install/config.rs
@@ -9,17 +9,10 @@ pub(super) enum Agent {
     Cursor,
     Claude,
     Codex,
-    Pi,
     OpenCode,
 }
 
-pub(super) const AGENTS: [Agent; 5] = [
-    Agent::Cursor,
-    Agent::Claude,
-    Agent::Codex,
-    Agent::Pi,
-    Agent::OpenCode,
-];
+pub(super) const AGENTS: [Agent; 4] = [Agent::Cursor, Agent::Claude, Agent::Codex, Agent::OpenCode];
 
 impl Agent {
     pub(super) fn name(self) -> &'static str {
@@ -27,7 +20,6 @@ impl Agent {
             Agent::Cursor => "Cursor",
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
-            Agent::Pi => "Pi",
             Agent::OpenCode => "OpenCode",
         }
     }
@@ -37,7 +29,6 @@ impl Agent {
             Agent::Cursor => "cursor",
             Agent::Claude => "claude",
             Agent::Codex => "codex",
-            Agent::Pi => "pi",
             Agent::OpenCode => "opencode",
         }
     }
@@ -47,7 +38,6 @@ impl Agent {
             Agent::Cursor => home.join(".cursor").join("hooks.json"),
             Agent::Claude => home.join(".claude").join("settings.json"),
             Agent::Codex => home.join(".codex").join("hooks.json"),
-            Agent::Pi => home.join(".pi").join("agent").join("settings.json"),
             Agent::OpenCode => home
                 .join(".config")
                 .join("opencode")
@@ -61,16 +51,19 @@ impl Agent {
             Agent::Cursor => home.join(".cursor"),
             Agent::Claude => home.join(".claude"),
             Agent::Codex => home.join(".codex"),
-            Agent::Pi => home.join(".pi"),
             Agent::OpenCode => home.join(".config").join("opencode"),
         }
     }
 
+    pub(super) fn skill_path(self, home: &Path) -> PathBuf {
+        self.home_dir(home)
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md")
+    }
+
     fn shell_matcher(self) -> &'static str {
-        match self {
-            Agent::Pi => "Bash|bash",
-            _ => "Bash",
-        }
+        "Bash"
     }
 
     /// Claude-compat `hooks.json` left by an older install. Native OpenCode
@@ -96,7 +89,7 @@ impl Agent {
                 .and_then(Value::as_array)
                 .map(|a| a.iter().any(command_is_lade_hook))
                 .unwrap_or(false),
-            Agent::Claude | Agent::Codex | Agent::Pi => root
+            Agent::Claude | Agent::Codex => root
                 .pointer("/hooks/PreToolUse")
                 .and_then(Value::as_array)
                 .map(|a| a.iter().any(matcher_has_hook))
@@ -107,6 +100,15 @@ impl Agent {
     }
 
     pub(super) fn hook_uses_command(self, existing: &str, command: &str) -> Result<bool> {
+        self.hook_uses_command_scoped(existing, command, false)
+    }
+
+    pub(super) fn hook_uses_command_scoped(
+        self,
+        existing: &str,
+        command: &str,
+        project: bool,
+    ) -> Result<bool> {
         if !self.has_hook(existing)? {
             return Ok(false);
         }
@@ -115,40 +117,29 @@ impl Agent {
         }
         let root = parse_root(existing, self)?;
         Ok(match self {
-            Agent::Cursor => root
-                .pointer("/hooks/preToolUse")
-                .and_then(Value::as_array)
-                .map(|entries| {
-                    entries.iter().any(|entry| {
-                        command_is_lade_hook(entry)
-                            && entry.get("command").and_then(Value::as_str) == Some(command)
-                    })
-                })
-                .unwrap_or(false),
-            Agent::Claude | Agent::Codex | Agent::Pi => root
-                .pointer("/hooks/PreToolUse")
-                .and_then(Value::as_array)
-                .map(|entries| {
-                    entries.iter().any(|entry| {
-                        entry
-                            .get("hooks")
-                            .and_then(Value::as_array)
-                            .map(|hooks| {
-                                hooks.iter().any(|hook| {
-                                    command_is_lade_hook(hook)
-                                        && hook.get("command").and_then(Value::as_str)
-                                            == Some(command)
-                                })
-                            })
-                            .unwrap_or(false)
-                    })
-                })
-                .unwrap_or(false),
+            Agent::Cursor => {
+                cursor_has_matcher(&root, "Shell", command)
+                    && cursor_has_matcher(&root, "MCP:", command)
+                    && (project || cursor_has_before_mcp(&root, command))
+            }
+            Agent::Claude | Agent::Codex => {
+                claude_has_matcher(&root, "Bash", command)
+                    && claude_has_matcher(&root, "mcp__.*", command)
+            }
             Agent::OpenCode => false,
         })
     }
 
     pub(super) fn merge(self, existing: &str, command: &str) -> Result<String> {
+        self.merge_scoped(existing, command, false)
+    }
+
+    pub(super) fn merge_scoped(
+        self,
+        existing: &str,
+        command: &str,
+        project: bool,
+    ) -> Result<String> {
         if matches!(self, Agent::OpenCode) {
             return Ok(opencode_plugin_body(command));
         }
@@ -159,23 +150,28 @@ impl Agent {
         match self {
             Agent::Cursor => {
                 obj.entry("version").or_insert_with(|| json!(1));
-                let arr = obj
+                let hooks = obj
                     .entry("hooks")
                     .or_insert_with(|| json!({}))
                     .as_object_mut()
-                    .context("\"hooks\" must be an object")?
+                    .context("\"hooks\" must be an object")?;
+                let arr = hooks
                     .entry("preToolUse")
                     .or_insert_with(|| json!([]))
                     .as_array_mut()
                     .context("\"preToolUse\" must be an array")?;
-                if let Some(entry) = arr.iter_mut().find(|e| command_is_lade_hook(e)) {
-                    entry["command"] = json!(command);
-                } else {
-                    arr.push(json!({ "command": command, "matcher": "Shell" }));
+                upsert_cursor_matcher(arr, command, "Shell");
+                upsert_cursor_matcher(arr, command, "MCP:");
+                if !project {
+                    let before = hooks
+                        .entry("beforeMCPExecution")
+                        .or_insert_with(|| json!([]))
+                        .as_array_mut()
+                        .context("\"beforeMCPExecution\" must be an array")?;
+                    upsert_cursor_before_mcp(before, command);
                 }
             }
-            Agent::Claude | Agent::Codex | Agent::Pi => {
-                let matcher = self.shell_matcher();
+            Agent::Claude | Agent::Codex => {
                 let arr = obj
                     .entry("hooks")
                     .or_insert_with(|| json!({}))
@@ -185,20 +181,8 @@ impl Agent {
                     .or_insert_with(|| json!([]))
                     .as_array_mut()
                     .context("\"PreToolUse\" must be an array")?;
-                if let Some(entry) = arr.iter_mut().find(|e| matcher_has_hook(e)) {
-                    if let Some(hooks) = entry.get_mut("hooks").and_then(Value::as_array_mut) {
-                        for hook in hooks.iter_mut() {
-                            if command_is_lade_hook(hook) {
-                                hook["command"] = json!(command);
-                            }
-                        }
-                    }
-                } else {
-                    arr.push(json!({
-                        "matcher": matcher,
-                        "hooks": [{ "type": "command", "command": command }]
-                    }));
-                }
+                upsert_claude_matcher(arr, command, self.shell_matcher());
+                upsert_claude_matcher(arr, command, "mcp__.*");
             }
             Agent::OpenCode => {}
         }
@@ -217,8 +201,15 @@ impl Agent {
                     {
                         arr.retain(|e| !command_is_lade_hook(e));
                     }
+                    if let Some(arr) = obj
+                        .get_mut("hooks")
+                        .and_then(|h| h.get_mut("beforeMCPExecution"))
+                        .and_then(Value::as_array_mut)
+                    {
+                        arr.retain(|e| !command_is_lade_hook(e));
+                    }
                 }
-                Agent::Claude | Agent::Codex | Agent::Pi | Agent::OpenCode => {
+                Agent::Claude | Agent::Codex | Agent::OpenCode => {
                     // OpenCode here is leftover Claude-compat hooks.json only.
                     if let Some(arr) = obj
                         .get_mut("hooks")
@@ -246,6 +237,92 @@ impl Agent {
         }
         to_pretty(&root)
     }
+}
+
+fn cursor_has_matcher(root: &Value, matcher: &str, command: &str) -> bool {
+    root.pointer("/hooks/preToolUse")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries.iter().any(|entry| {
+                command_is_lade_hook(entry)
+                    && entry.get("matcher").and_then(Value::as_str) == Some(matcher)
+                    && entry.get("command").and_then(Value::as_str) == Some(command)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn cursor_has_before_mcp(root: &Value, command: &str) -> bool {
+    root.pointer("/hooks/beforeMCPExecution")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries.iter().any(|entry| {
+                command_is_lade_hook(entry)
+                    && entry.get("command").and_then(Value::as_str) == Some(command)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn claude_has_matcher(root: &Value, matcher: &str, command: &str) -> bool {
+    root.pointer("/hooks/PreToolUse")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries.iter().any(|entry| {
+                entry.get("matcher").and_then(Value::as_str) == Some(matcher)
+                    && entry
+                        .get("hooks")
+                        .and_then(Value::as_array)
+                        .map(|hooks| {
+                            hooks.iter().any(|hook| {
+                                command_is_lade_hook(hook)
+                                    && hook.get("command").and_then(Value::as_str) == Some(command)
+                            })
+                        })
+                        .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn upsert_cursor_matcher(arr: &mut Vec<Value>, command: &str, matcher: &str) {
+    if let Some(entry) = arr.iter_mut().find(|entry| {
+        command_is_lade_hook(entry) && entry.get("matcher").and_then(Value::as_str) == Some(matcher)
+    }) {
+        entry["command"] = json!(command);
+        return;
+    }
+    arr.push(json!({ "command": command, "matcher": matcher }));
+}
+
+fn upsert_cursor_before_mcp(arr: &mut Vec<Value>, command: &str) {
+    if let Some(entry) = arr.iter_mut().find(|entry| command_is_lade_hook(entry)) {
+        entry["command"] = json!(command);
+        return;
+    }
+    arr.push(json!({ "command": command }));
+}
+
+fn upsert_claude_matcher(arr: &mut Vec<Value>, command: &str, matcher: &str) {
+    if let Some(entry) = arr
+        .iter_mut()
+        .find(|entry| entry.get("matcher").and_then(Value::as_str) == Some(matcher))
+    {
+        if let Some(hooks) = entry.get_mut("hooks").and_then(Value::as_array_mut) {
+            if let Some(hook) = hooks.iter_mut().find(|hook| command_is_lade_hook(hook)) {
+                hook["command"] = json!(command);
+                return;
+            }
+            hooks.push(json!({ "type": "command", "command": command }));
+            return;
+        }
+        entry["hooks"] = json!([{ "type": "command", "command": command }]);
+        return;
+    }
+    arr.push(json!({
+        "matcher": matcher,
+        "hooks": [{ "type": "command", "command": command }]
+    }));
 }
 
 fn matcher_has_hook(entry: &Value) -> bool {
@@ -308,27 +385,44 @@ fn opencode_plugin_body(command: &str) -> String {
         r#"import {{ spawnSync }} from "node:child_process";
 
 const lade = process.env.LADE_BIN ?? "{bin}";
+const local = new Set(["bash", "read", "write", "grep", "toolsearch", "edit", "glob", "list"]);
 
 // OpenCode loads every exported function in this file and calls it for hooks.
 export const LadePretool = async () => ({{
   "tool.execute.before": async (input, output) => {{
-    const command = output.args?.command;
-    if (input.tool !== "bash" || typeof command !== "string") {{
+    const tool = input.tool;
+    if (tool === "bash") {{
+      const command = output.args?.command;
+      if (typeof command !== "string") {{
+        return;
+      }}
+      const result = spawnSync(lade, ["hook", "--harness", "opencode"], {{
+        input: JSON.stringify({{ command, session_id: input.sessionID }}),
+        encoding: "utf8",
+      }});
+      if (result.status !== 0 || !result.stdout?.trim()) {{
+        return;
+      }}
+      try {{
+        const updated = JSON.parse(result.stdout)?.command;
+        if (typeof updated === "string") {{
+          output.args.command = updated;
+        }}
+      }} catch {{}}
       return;
     }}
-    const result = spawnSync(lade, ["hook", "--harness", "opencode"], {{
-      input: JSON.stringify({{ command, session_id: input.sessionID }}),
+    if (typeof tool !== "string" || local.has(tool.toLowerCase())) {{
+      return;
+    }}
+    spawnSync(lade, ["hook", "--harness", "opencode"], {{
+      input: JSON.stringify({{
+        tool,
+        args: output.args ?? {{}},
+        session_id: input.sessionID,
+        hook_source: "opencode-plugin",
+      }}),
       encoding: "utf8",
     }});
-    if (result.status !== 0 || !result.stdout?.trim()) {{
-      return;
-    }}
-    try {{
-      const updated = JSON.parse(result.stdout)?.command;
-      if (typeof updated === "string") {{
-        output.args.command = updated;
-      }}
-    }} catch {{}}
   }},
 }});
 "#

--- a/src/pretool/install/mod.rs
+++ b/src/pretool/install/mod.rs
@@ -1,9 +1,9 @@
 //! Optional installation of the `lade hook` interceptor into the agents that
-//! support `preToolUse` shell hooks (Cursor, Claude Code, Codex, Pi, OpenCode).
+//! support `preToolUse` shell hooks (Cursor, Claude Code, Codex, OpenCode).
 //!
 //! `lade install` is a global, once-only operation, so these hooks are written
 //! to the agents' global config (`~/.cursor/hooks.json`,
-//! `~/.claude/settings.json`, `~/.codex/hooks.json`, `~/.pi/agent/settings.json`,
+//! `~/.claude/settings.json`, `~/.codex/hooks.json`,
 //! `~/.config/opencode/plugins/lade-pretool.js`). We only act when the agent's
 //! home dir already exists and never overwrite unrelated settings.
 
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use config::AGENTS;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::message_box::MessageBox;
 
@@ -45,6 +46,44 @@ fn hook_command(agent: config::Agent) -> String {
     format!("{} hook --harness {}", install_bin(), agent.slug())
 }
 
+pub(super) const SKILL_MD: &str = include_str!("../../../.agents/skills/lade/SKILL.md");
+
+/// sha256 of official SKILL.md blobs this binary still rewrites.
+const SKILL_PREVIOUS: &[&str] = &[
+    "1e8636e98007c49b9b2cb78f716c67e714fbda2bfdcd6070c0abda9b436a914a",
+    "dee189b102053fbc2a672bcfa6ce7a6b6e4c483ba68ee71244848d60f35fedca",
+];
+
+fn skill_sha256(content: &str) -> String {
+    hex::encode(Sha256::digest(content.as_bytes()))
+}
+
+pub(super) fn is_lade_skill(content: &str) -> bool {
+    skill_is_current(content)
+        || SKILL_PREVIOUS
+            .iter()
+            .any(|known| *known == skill_sha256(content))
+        || test_previous_official(content)
+}
+
+#[cfg(test)]
+const STALE_OFFICIAL: &str =
+    "---\nname: lade\ndescription: previous official lade skill\n---\n\n# Lade\n";
+
+#[cfg(test)]
+fn test_previous_official(content: &str) -> bool {
+    content == STALE_OFFICIAL
+}
+
+#[cfg(not(test))]
+fn test_previous_official(_: &str) -> bool {
+    false
+}
+
+pub(super) fn skill_is_current(content: &str) -> bool {
+    content == SKILL_MD
+}
+
 fn tilde(path: &Path, home: &Path) -> String {
     match path.strip_prefix(home) {
         Ok(rest) => format!("~/{}", rest.display()),
@@ -52,8 +91,8 @@ fn tilde(path: &Path, home: &Path) -> String {
     }
 }
 
-fn confirm(name: &str, path: &str) -> Result<bool> {
-    eprint!("Install Lade hook for {name} in {path}? [y/N]: ");
+fn confirm(kind: &str, name: &str, path: &str) -> Result<bool> {
+    eprint!("Install Lade {kind} for {name} in {path}? [y/N]: ");
     io::stderr().flush()?;
     let mut answer = String::new();
     io::stdin().read_line(&mut answer)?;
@@ -61,11 +100,11 @@ fn confirm(name: &str, path: &str) -> Result<bool> {
     Ok(answer == "y" || answer == "yes")
 }
 
-fn report(results: Vec<String>) {
+fn report(title: &str, results: Vec<String>) {
     if results.is_empty() {
         return;
     }
-    let mut mb = MessageBox::new().info().line("preTool hooks:");
+    let mut mb = MessageBox::new().info().line(title);
     for result in results {
         mb = mb.line(format!("- {result}"));
     }
@@ -76,58 +115,129 @@ fn report(results: Vec<String>) {
 /// machine. `may_prompt` must be true only when both stdin and stderr are TTYs.
 pub fn install(may_prompt: bool) -> Result<()> {
     let home = home_dir()?;
-    let mut results = Vec::new();
+    let mut hook_results = Vec::new();
+    let mut skill_results = Vec::new();
 
     for agent in AGENTS {
-        let command = hook_command(agent);
         if !agent.home_dir(&home).is_dir() {
             continue;
         }
-        let path = agent.config_path(&home);
-        let existing = fs::read_to_string(&path).unwrap_or_default();
-        if agent.has_hook(&existing)? {
-            if agent.hook_uses_command(&existing, &command)? {
-                results.push(format!("{}: hook already present", agent.name()));
-                continue;
-            }
-            if !may_prompt {
-                results.push(format!(
-                    "{}: detected. Re-run `lade install` in a terminal to update its hook",
-                    agent.name()
-                ));
-                continue;
-            }
-            fs::write(&path, agent.merge(&existing, &command)?)?;
-            results.push(format!(
-                "{}: hook updated in {}",
-                agent.name(),
-                tilde(&path, &home)
-            ));
-            continue;
+        install_hook(agent, &home, may_prompt, &mut hook_results)?;
+        install_skill(agent, &home, may_prompt, &mut skill_results)?;
+    }
+
+    report("preTool hooks:", hook_results);
+    report("skills:", skill_results);
+    Ok(())
+}
+
+fn install_hook(
+    agent: config::Agent,
+    home: &Path,
+    may_prompt: bool,
+    results: &mut Vec<String>,
+) -> Result<()> {
+    let command = hook_command(agent);
+    let path = agent.config_path(home);
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    if agent.has_hook(&existing)? {
+        if agent.hook_uses_command_scoped(&existing, &command, false)? {
+            results.push(format!("{}: hook already present", agent.name()));
+            return Ok(());
         }
         if !may_prompt {
             results.push(format!(
-                "{}: detected. Re-run `lade install` in a terminal to add its hook",
+                "{}: detected. Re-run `lade install` in a terminal to update its hook",
                 agent.name()
             ));
-            continue;
+            return Ok(());
         }
-        if confirm(agent.name(), &tilde(&path, &home))? {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&path, agent.merge(&existing, &command)?)?;
-            results.push(format!(
-                "{}: hook installed in {}",
-                agent.name(),
-                tilde(&path, &home)
-            ));
-        } else {
-            results.push(format!("{}: skipped", agent.name()));
-        }
+        fs::write(&path, agent.merge(&existing, &command)?)?;
+        results.push(format!(
+            "{}: hook updated in {}",
+            agent.name(),
+            tilde(&path, home)
+        ));
+        return Ok(());
     }
+    if !may_prompt {
+        results.push(format!(
+            "{}: detected. Re-run `lade install` in a terminal to add its hook",
+            agent.name()
+        ));
+        return Ok(());
+    }
+    if confirm("hook", agent.name(), &tilde(&path, home))? {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, agent.merge(&existing, &command)?)?;
+        results.push(format!(
+            "{}: hook installed in {}",
+            agent.name(),
+            tilde(&path, home)
+        ));
+    } else {
+        results.push(format!("{}: hook skipped", agent.name()));
+    }
+    Ok(())
+}
 
-    report(results);
+fn install_skill(
+    agent: config::Agent,
+    home: &Path,
+    may_prompt: bool,
+    results: &mut Vec<String>,
+) -> Result<()> {
+    let path = agent.skill_path(home);
+    if path.is_file() {
+        let existing = fs::read_to_string(&path).unwrap_or_default();
+        if !is_lade_skill(&existing) {
+            results.push(format!(
+                "{}: skill present but not Lade-managed",
+                agent.name()
+            ));
+            return Ok(());
+        }
+        if skill_is_current(&existing) {
+            results.push(format!("{}: skill already present", agent.name()));
+            return Ok(());
+        }
+        if !may_prompt {
+            results.push(format!(
+                "{}: detected. Re-run `lade install` in a terminal to update its skill",
+                agent.name()
+            ));
+            return Ok(());
+        }
+        fs::write(&path, SKILL_MD)?;
+        results.push(format!(
+            "{}: skill updated in {}",
+            agent.name(),
+            tilde(&path, home)
+        ));
+        return Ok(());
+    }
+    if !may_prompt {
+        results.push(format!(
+            "{}: detected. Re-run `lade install` in a terminal to add its skill",
+            agent.name()
+        ));
+        return Ok(());
+    }
+    if confirm("skill", agent.name(), &tilde(&path, home))? {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, SKILL_MD)?;
+        results.push(format!(
+            "{}: skill installed in {}",
+            agent.name(),
+            tilde(&path, home)
+        ));
+    } else {
+        results.push(format!("{}: skill skipped", agent.name()));
+    }
     Ok(())
 }
 
@@ -152,14 +262,31 @@ pub fn refresh_installed() {
 pub(crate) fn refresh_at(home: &Path, cwd: &Path) {
     for agent in AGENTS {
         let command = hook_command(agent);
-        refresh_path(agent, &agent.config_path(home), &command);
+        refresh_path(agent, &agent.config_path(home), &command, false);
         if let Ok((project_path, true)) = find_project(agent, home, cwd) {
-            refresh_path(agent, &project_path, &command);
+            refresh_path(agent, &project_path, &command, true);
         }
+        refresh_skill(&agent.skill_path(home));
+        if let Ok((path, true)) = find_project_skill(agent, home, cwd) {
+            refresh_skill(&path);
+        }
+    }
+    if let Some(path) = find_agents_skill(home, cwd) {
+        refresh_skill(&path);
     }
 }
 
-fn refresh_path(agent: config::Agent, path: &Path, command: &str) {
+fn refresh_skill(path: &Path) {
+    let Ok(existing) = fs::read_to_string(path) else {
+        return;
+    };
+    if !is_lade_skill(&existing) || skill_is_current(&existing) {
+        return;
+    }
+    let _ = fs::write(path, SKILL_MD);
+}
+
+fn refresh_path(agent: config::Agent, path: &Path, command: &str, project: bool) {
     let Ok(existing) = fs::read_to_string(path) else {
         return;
     };
@@ -167,12 +294,12 @@ fn refresh_path(agent: config::Agent, path: &Path, command: &str) {
         Ok(true) => {}
         _ => return,
     }
-    match agent.hook_uses_command(&existing, command) {
+    match agent.hook_uses_command_scoped(&existing, command, project) {
         Ok(true) => return,
         Ok(false) => {}
         Err(_) => return,
     }
-    if let Ok(updated) = agent.merge(&existing, command) {
+    if let Ok(updated) = agent.merge_scoped(&existing, command, project) {
         let _ = fs::write(path, updated);
     }
 }
@@ -180,32 +307,50 @@ fn refresh_path(agent: config::Agent, path: &Path, command: &str) {
 /// Remove the `lade hook` interceptor from every agent config that contains it.
 pub fn uninstall() -> Result<()> {
     let home = home_dir()?;
-    let mut results = Vec::new();
+    let mut hook_results = Vec::new();
+    let mut skill_results = Vec::new();
 
     for agent in AGENTS {
         let path = agent.config_path(&home);
         let existing = fs::read_to_string(&path).unwrap_or_default();
         let legacy = leftover_json_hook(agent, &home)?;
-        if !agent.has_hook(&existing)? && legacy.is_none() {
-            continue;
+        if agent.has_hook(&existing)? || legacy.is_some() {
+            if matches!(agent, config::Agent::OpenCode) {
+                let _ = fs::remove_file(&path);
+            } else if agent.has_hook(&existing)? {
+                fs::write(&path, agent.remove(&existing)?)?;
+            }
+            if let Some((legacy_path, content)) = legacy {
+                fs::write(&legacy_path, agent.remove(&content)?)?;
+            }
+            hook_results.push(format!(
+                "{}: hook removed from {}",
+                agent.name(),
+                tilde(&path, &home)
+            ));
         }
-        if matches!(agent, config::Agent::OpenCode) {
-            let _ = fs::remove_file(&path);
-        } else if agent.has_hook(&existing)? {
-            fs::write(&path, agent.remove(&existing)?)?;
-        }
-        if let Some((legacy_path, content)) = legacy {
-            fs::write(&legacy_path, agent.remove(&content)?)?;
-        }
-        results.push(format!(
-            "{}: hook removed from {}",
-            agent.name(),
-            tilde(&path, &home)
-        ));
+        uninstall_skill(agent, &home, &mut skill_results);
     }
 
-    report(results);
+    report("preTool hooks:", hook_results);
+    report("skills:", skill_results);
     Ok(())
+}
+
+fn uninstall_skill(agent: config::Agent, home: &Path, results: &mut Vec<String>) {
+    let path = agent.skill_path(home);
+    let Ok(content) = fs::read_to_string(&path) else {
+        return;
+    };
+    if !is_lade_skill(&content) {
+        return;
+    }
+    let _ = fs::remove_file(&path);
+    results.push(format!(
+        "{}: skill removed from {}",
+        agent.name(),
+        tilde(&path, home)
+    ));
 }
 
 #[derive(Debug, Serialize)]
@@ -226,8 +371,51 @@ pub struct PretoolStatus {
     pub cursor: PretoolAgentStatus,
     pub claude: PretoolAgentStatus,
     pub codex: PretoolAgentStatus,
-    pub pi: PretoolAgentStatus,
     pub opencode: PretoolAgentStatus,
+}
+
+pub type SkillsStatus = PretoolStatus;
+
+/// Global and project-local Lade-managed skills.
+pub fn inspect_skills(cwd: &Path) -> Result<SkillsStatus> {
+    let home = home_dir()?;
+    Ok(SkillsStatus {
+        cursor: inspect_skill_agent(config::Agent::Cursor, &home, cwd)?,
+        claude: inspect_skill_agent(config::Agent::Claude, &home, cwd)?,
+        codex: inspect_skill_agent(config::Agent::Codex, &home, cwd)?,
+        opencode: inspect_skill_agent(config::Agent::OpenCode, &home, cwd)?,
+    })
+}
+
+fn inspect_skill_agent(
+    agent: config::Agent,
+    home: &Path,
+    cwd: &Path,
+) -> Result<PretoolAgentStatus> {
+    let global_path = agent.skill_path(home);
+    let (global_installed, global_current) = skill_state(&global_path);
+    let (project_path, project_installed) = find_project_skill(agent, home, cwd)?;
+    let project_current = project_installed && skill_state(&project_path).1;
+    Ok(PretoolAgentStatus {
+        global: HookLocation {
+            path: global_path,
+            installed: global_installed,
+            current: global_current,
+        },
+        project: HookLocation {
+            path: project_path,
+            installed: project_installed,
+            current: project_current,
+        },
+    })
+}
+
+fn skill_state(path: &Path) -> (bool, bool) {
+    let Ok(content) = fs::read_to_string(path) else {
+        return (false, false);
+    };
+    let installed = is_lade_skill(&content);
+    (installed, installed && skill_is_current(&content))
 }
 
 /// Global and project-local `lade hook` entries for supported agents.
@@ -237,7 +425,6 @@ pub fn inspect(cwd: &Path) -> Result<PretoolStatus> {
         cursor: inspect_agent(config::Agent::Cursor, &home, cwd)?,
         claude: inspect_agent(config::Agent::Claude, &home, cwd)?,
         codex: inspect_agent(config::Agent::Codex, &home, cwd)?,
-        pi: inspect_agent(config::Agent::Pi, &home, cwd)?,
         opencode: inspect_agent(config::Agent::OpenCode, &home, cwd)?,
     })
 }
@@ -309,6 +496,80 @@ fn find_project(agent: config::Agent, home: &Path, cwd: &Path) -> Result<(PathBu
     Ok((canonical_project_path(agent, cwd), false))
 }
 
+fn find_project_skill(agent: config::Agent, home: &Path, cwd: &Path) -> Result<(PathBuf, bool)> {
+    let under_home = cwd.starts_with(home);
+    let mut dir = cwd.to_path_buf();
+    loop {
+        if dir == home {
+            break;
+        }
+        let path = project_skill_file(agent, &dir);
+        if path.is_file() && skill_state(&path).0 {
+            return Ok((path, true));
+        }
+        if path.is_file() {
+            return Ok((path, false));
+        }
+        match dir.parent() {
+            Some(parent) if under_home => dir = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    Ok((canonical_project_skill_path(agent, cwd), false))
+}
+
+fn find_agents_skill(home: &Path, cwd: &Path) -> Option<PathBuf> {
+    let under_home = cwd.starts_with(home);
+    let mut dir = cwd.to_path_buf();
+    loop {
+        if dir == home {
+            break;
+        }
+        let path = dir
+            .join(".agents")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md");
+        if path.is_file() {
+            return Some(path);
+        }
+        match dir.parent() {
+            Some(parent) if under_home => dir = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    None
+}
+
+fn project_skill_file(agent: config::Agent, dir: &Path) -> PathBuf {
+    match agent {
+        config::Agent::Cursor => dir
+            .join(".cursor")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md"),
+        config::Agent::Claude => dir
+            .join(".claude")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md"),
+        config::Agent::Codex => dir
+            .join(".codex")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md"),
+        config::Agent::OpenCode => dir
+            .join(".opencode")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md"),
+    }
+}
+
+fn canonical_project_skill_path(agent: config::Agent, cwd: &Path) -> PathBuf {
+    project_skill_file(agent, cwd)
+}
+
 fn project_files(agent: config::Agent, dir: &Path) -> Vec<PathBuf> {
     match agent {
         config::Agent::Cursor => vec![dir.join(".cursor").join("hooks.json")],
@@ -317,10 +578,6 @@ fn project_files(agent: config::Agent, dir: &Path) -> Vec<PathBuf> {
             dir.join(".claude").join("settings.json"),
         ],
         config::Agent::Codex => vec![dir.join(".codex").join("hooks.json")],
-        config::Agent::Pi => vec![
-            dir.join(".pi").join("settings.json"),
-            dir.join(".pi").join("hooks.json"),
-        ],
         config::Agent::OpenCode => vec![
             dir.join(".opencode")
                 .join("plugins")
@@ -334,7 +591,6 @@ fn canonical_project_path(agent: config::Agent, cwd: &Path) -> PathBuf {
         config::Agent::Cursor => cwd.join(".cursor").join("hooks.json"),
         config::Agent::Claude => cwd.join(".claude").join("settings.json"),
         config::Agent::Codex => cwd.join(".codex").join("hooks.json"),
-        config::Agent::Pi => cwd.join(".pi").join("settings.json"),
         config::Agent::OpenCode => cwd
             .join(".opencode")
             .join("plugins")

--- a/src/pretool/install/tests.rs
+++ b/src/pretool/install/tests.rs
@@ -43,9 +43,17 @@ fn cursor_merge_from_empty_sets_version_and_hook() {
     let v: Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["version"], 1);
     let arr = v["hooks"]["preToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["command"], CMD);
-    assert_eq!(arr[0]["matcher"], "Shell");
+    assert_eq!(arr.len(), 2);
+    assert!(
+        arr.iter()
+            .any(|e| e["matcher"] == "Shell" && e["command"] == CMD)
+    );
+    assert!(
+        arr.iter()
+            .any(|e| e["matcher"] == "MCP:" && e["command"] == CMD)
+    );
+    assert_eq!(v["hooks"]["beforeMCPExecution"][0]["command"], CMD);
+    assert!(v["hooks"]["beforeMCPExecution"][0].get("matcher").is_none());
     assert!(Agent::Cursor.has_hook(&out).unwrap());
 }
 
@@ -54,8 +62,14 @@ fn cursor_merge_is_idempotent() {
     let once = Agent::Cursor.merge("", CMD).unwrap();
     let twice = Agent::Cursor.merge(&once, "lade hook").unwrap();
     let v: Value = serde_json::from_str(&twice).unwrap();
-    assert_eq!(v["hooks"]["preToolUse"].as_array().unwrap().len(), 1);
-    assert_eq!(v["hooks"]["preToolUse"][0]["command"], "lade hook");
+    assert_eq!(v["hooks"]["preToolUse"].as_array().unwrap().len(), 2);
+    assert!(
+        v["hooks"]["preToolUse"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["command"] == "lade hook")
+    );
 }
 
 #[test]
@@ -77,9 +91,16 @@ fn cursor_merge_preserves_existing_hooks() {
     let out = Agent::Cursor.merge(existing, CMD).unwrap();
     let v: Value = serde_json::from_str(&out).unwrap();
     let arr = v["hooks"]["preToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 2);
+    assert_eq!(arr.len(), 3);
     assert!(arr.iter().any(|e| e["command"] == "other tool"));
-    assert!(arr.iter().any(|e| e["command"] == CMD));
+    assert!(
+        arr.iter()
+            .any(|e| e["matcher"] == "Shell" && e["command"] == CMD)
+    );
+    assert!(
+        arr.iter()
+            .any(|e| e["matcher"] == "MCP:" && e["command"] == CMD)
+    );
     assert_eq!(v["hooks"]["afterFileEdit"][0]["command"], "fmt");
 }
 
@@ -104,10 +125,11 @@ fn claude_merge_from_empty_adds_bash_matcher() {
     let out = Agent::Claude.merge("", CMD).unwrap();
     let v: Value = serde_json::from_str(&out).unwrap();
     let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["matcher"], "Bash");
+    assert_eq!(arr.len(), 2);
+    assert!(arr.iter().any(|e| e["matcher"] == "Bash"));
+    assert!(arr.iter().any(|e| e["matcher"] == "mcp__.*"));
     assert_eq!(arr[0]["hooks"][0]["type"], "command");
-    assert_eq!(arr[0]["hooks"][0]["command"], CMD);
+    assert!(arr.iter().all(|e| e["hooks"][0]["command"] == CMD));
     assert!(Agent::Claude.has_hook(&out).unwrap());
 }
 
@@ -116,10 +138,13 @@ fn claude_merge_is_idempotent() {
     let once = Agent::Claude.merge("", CMD).unwrap();
     let twice = Agent::Claude.merge(&once, "lade hook").unwrap();
     let v: Value = serde_json::from_str(&twice).unwrap();
-    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
-    assert_eq!(
-        v["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
-        "lade hook"
+    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 2);
+    assert!(
+        v["hooks"]["PreToolUse"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["hooks"][0]["command"] == "lade hook")
     );
 }
 
@@ -130,9 +155,10 @@ fn claude_merge_preserves_existing_settings() {
     let v: Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["model"], "sonnet");
     let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 2);
+    assert_eq!(arr.len(), 3);
     assert!(arr.iter().any(|e| e["matcher"] == "Write"));
     assert!(arr.iter().any(|e| e["matcher"] == "Bash"));
+    assert!(arr.iter().any(|e| e["matcher"] == "mcp__.*"));
 }
 
 #[test]
@@ -152,16 +178,7 @@ fn has_hook_false_on_empty() {
     assert!(!Agent::Cursor.has_hook("").unwrap());
     assert!(!Agent::Claude.has_hook("   ").unwrap());
     assert!(!Agent::Codex.has_hook("").unwrap());
-    assert!(!Agent::Pi.has_hook("").unwrap());
     assert!(!Agent::OpenCode.has_hook("").unwrap());
-}
-
-#[test]
-fn pi_merge_uses_bash_or_bash_matcher() {
-    let out = Agent::Pi.merge("", CMD).unwrap();
-    let v: Value = serde_json::from_str(&out).unwrap();
-    assert_eq!(v["hooks"]["PreToolUse"][0]["matcher"], "Bash|bash");
-    assert!(Agent::Pi.has_hook(&out).unwrap());
 }
 
 #[test]
@@ -188,10 +205,11 @@ fn codex_merge_from_empty_adds_bash_matcher() {
     let out = Agent::Codex.merge("", CMD).unwrap();
     let v: Value = serde_json::from_str(&out).unwrap();
     let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["matcher"], "Bash");
+    assert_eq!(arr.len(), 2);
+    assert!(arr.iter().any(|e| e["matcher"] == "Bash"));
+    assert!(arr.iter().any(|e| e["matcher"] == "mcp__.*"));
     assert_eq!(arr[0]["hooks"][0]["type"], "command");
-    assert_eq!(arr[0]["hooks"][0]["command"], CMD);
+    assert!(arr.iter().all(|e| e["hooks"][0]["command"] == CMD));
     assert!(Agent::Codex.has_hook(&out).unwrap());
 }
 
@@ -200,10 +218,13 @@ fn codex_merge_is_idempotent() {
     let once = Agent::Codex.merge("", CMD).unwrap();
     let twice = Agent::Codex.merge(&once, "lade hook").unwrap();
     let v: Value = serde_json::from_str(&twice).unwrap();
-    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 1);
-    assert_eq!(
-        v["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
-        "lade hook"
+    assert_eq!(v["hooks"]["PreToolUse"].as_array().unwrap().len(), 2);
+    assert!(
+        v["hooks"]["PreToolUse"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["hooks"][0]["command"] == "lade hook")
     );
 }
 
@@ -214,9 +235,10 @@ fn codex_merge_preserves_existing_hooks() {
     let v: Value = serde_json::from_str(&out).unwrap();
     assert_eq!(v["description"], "repo");
     let arr = v["hooks"]["PreToolUse"].as_array().unwrap();
-    assert_eq!(arr.len(), 2);
+    assert_eq!(arr.len(), 3);
     assert!(arr.iter().any(|e| e["matcher"] == "apply_patch"));
     assert!(arr.iter().any(|e| e["matcher"] == "Bash"));
+    assert!(arr.iter().any(|e| e["matcher"] == "mcp__.*"));
 }
 
 #[test]
@@ -229,6 +251,24 @@ fn codex_remove_prunes_only_our_matcher() {
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["matcher"], "apply_patch");
     assert!(!Agent::Codex.has_hook(&cleaned).unwrap());
+}
+
+#[test]
+#[test]
+fn cursor_project_merge_skips_before_mcp() {
+    let out = Agent::Cursor.merge_scoped("", CMD, true).unwrap();
+    let v: Value = serde_json::from_str(&out).unwrap();
+    assert!(v["hooks"].get("beforeMCPExecution").is_none());
+    assert!(
+        Agent::Cursor
+            .hook_uses_command_scoped(&out, CMD, true)
+            .unwrap()
+    );
+    assert!(
+        !Agent::Cursor
+            .hook_uses_command_scoped(&out, CMD, false)
+            .unwrap()
+    );
 }
 
 #[test]
@@ -308,6 +348,61 @@ fn find_project_finds_repo_codex_hooks_before_home() {
     assert_eq!(path, repo.join(".codex").join("hooks.json"));
 }
 
+fn stale_official_skill() -> &'static str {
+    super::STALE_OFFICIAL
+}
+
+#[test]
+fn skill_path_sits_under_the_agent_home() {
+    let home = std::path::Path::new("/tmp/home");
+    assert_eq!(
+        Agent::Cursor.skill_path(home),
+        home.join(".cursor")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md")
+    );
+    assert_eq!(
+        Agent::OpenCode.skill_path(home),
+        home.join(".config")
+            .join("opencode")
+            .join("skills")
+            .join("lade")
+            .join("SKILL.md")
+    );
+}
+
+#[test]
+fn bundled_skill_is_lade_managed() {
+    assert!(super::is_lade_skill(super::SKILL_MD));
+    assert!(super::skill_is_current(super::SKILL_MD));
+    assert!(super::is_lade_skill(&stale_official_skill()));
+    assert!(!super::skill_is_current(&stale_official_skill()));
+    assert!(!super::is_lade_skill("# mine\n"));
+}
+
+#[test]
+fn refresh_updates_stale_managed_skill_and_skips_unmanaged() {
+    let home = tempfile::tempdir().unwrap();
+    let path = Agent::Codex.skill_path(home.path());
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, stale_official_skill()).unwrap();
+    let foreign = Agent::Claude.skill_path(home.path());
+    std::fs::create_dir_all(foreign.parent().unwrap()).unwrap();
+    std::fs::write(&foreign, "# mine\n").unwrap();
+    super::refresh_at(home.path(), home.path());
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), super::SKILL_MD);
+    assert_eq!(std::fs::read_to_string(&foreign).unwrap(), "# mine\n");
+}
+
+#[test]
+fn refresh_does_not_create_a_missing_skill() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+    super::refresh_at(home.path(), home.path());
+    assert!(!Agent::Codex.skill_path(home.path()).exists());
+}
+
 #[test]
 fn refresh_updates_stale_hook_and_skips_missing() {
     let home = tempfile::tempdir().unwrap();
@@ -317,8 +412,8 @@ fn refresh_updates_stale_hook_and_skips_missing() {
     let stale = r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"lade hook"}]}]}}"#;
     std::fs::write(&global, stale).unwrap();
     let command = "/usr/local/bin/lade hook --harness codex";
-    super::refresh_path(Agent::Codex, &global, command);
-    super::refresh_path(Agent::Claude, &other, command);
+    super::refresh_path(Agent::Codex, &global, command, false);
+    super::refresh_path(Agent::Claude, &other, command, false);
     let updated = std::fs::read_to_string(&global).unwrap();
     assert!(Agent::Codex.hook_uses_command(&updated, command).unwrap());
     assert!(!other.exists());

--- a/src/pretool/mod.rs
+++ b/src/pretool/mod.rs
@@ -11,19 +11,17 @@ Disclaimer enforcement lives in inject.
 - Input: `{"tool_name": "Shell", "tool_input": {"command": "..."}, "hook_event_name": "preToolUse", ...}`
 - Output: `{"permission": "allow", "updated_input": {...}}`
 
-# Claude-compatible PreToolUse (Claude Code, Codex, Pi)
+# Claude-compatible PreToolUse (Claude Code, Codex)
 - Claude: `CLAUDE_PROJECT_DIR` — https://code.claude.com/docs/en/hooks
 - Codex: `CODEX_THREAD_ID` / `CODEX_SANDBOX` / `CODEX_HOME`, plus `turn_id`/`model`
   — https://developers.openai.com/codex/hooks
-- Pi: `PI_HOME` / `PI_CODING_AGENT`, payload `tool_name` is often `bash`
 - OpenCode: `--harness opencode`, or `OPENCODE` / `OPENCODE_DIR` /
   `hook_source=opencode-plugin`
 - Input (Claude-compat): `{"tool_name": "Bash"|"bash",
   "tool_input": {"command": "..."}, "hook_event_name": "PreToolUse", ...}`
 - Output (Claude-compat): `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
   "permissionDecision": "allow", "updatedInput": {...}}}`. Exit 0 with no
-  stdout allows the original command. Shell tools match as `Bash` (or `bash`
-  on Pi).
+  stdout allows the original command. Shell tools match as `Bash`.
 - OpenCode plugin input: `{"command": "...", "session_id": "..."}`.
   Output: `{"command": "..."}`.
 */
@@ -33,6 +31,7 @@ mod platform;
 mod response;
 #[cfg(test)]
 mod tests;
+mod verb;
 
 use crate::audience::Via;
 use crate::config::{Audience, Config};
@@ -49,9 +48,10 @@ use platform::{
     collect_agent, extract_command, has_pretool_stamp, is_already_injected, resolve_platform,
     split_env_prefix,
 };
+use verb::{hook_event, is_post_event, is_verb, normalize, verb_agent, verb_args};
 
 pub(crate) use platform::split_env_prefix as split_command_env_prefix;
-use response::{format_allow, format_modify};
+use response::{format_allow, format_allow_verb, format_modify};
 
 fn pretool_flag() -> &'static str {
     "--pretool"
@@ -87,6 +87,12 @@ pub fn handle(
 ) -> Result<String> {
     let parsed: Value = serde_json::from_str(input).unwrap_or(json!({}));
     let platform = resolve_platform(harness, &parsed);
+    if is_post_event(&parsed) {
+        return Ok(allow_verb(platform));
+    }
+    if is_verb(&parsed) {
+        return handle_verb(config, &parsed, platform, audience);
+    }
     let agent = collect_agent(platform, &parsed);
 
     let raw = match extract_command(&parsed) {
@@ -126,6 +132,7 @@ pub fn handle(
                     actor: event::actor(&saved_user),
                     cwd,
                     command: command.clone(),
+                    argv: None,
                     hydrated: None,
                     matches: json!([]),
                     hydrate_ms: None,
@@ -184,10 +191,58 @@ pub fn handle(
     Ok(modify(platform, &tool_input, &new_command))
 }
 
+fn handle_verb(
+    config: &Config,
+    parsed: &Value,
+    platform: Option<platform::Platform>,
+    audience: Audience,
+) -> Result<String> {
+    let command = normalize(parsed);
+    let argv = verb_args(parsed);
+    let patterned = config.collect_for_with_pattern(&command, audience);
+    let saved_user = GlobalConfig::user_from_disk();
+    let (log, matches) = if patterned.is_empty() {
+        (config.log_on_walk(), json!([]))
+    } else {
+        match Config::pre_event_work(&patterned, &saved_user) {
+            Ok(work) => (work.log, work.matches),
+            Err(_) => (config.log_on_walk(), json!([])),
+        }
+    };
+    let agent = crate::agent_meta::merge(verb_agent(collect_agent(platform, parsed), parsed));
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    event::emit_verb(
+        log,
+        hook_event(parsed),
+        parsed.get("tool_use_id").and_then(Value::as_str),
+        Emit {
+            kind: Kind::Seen,
+            via: Via::Mcp,
+            audience,
+            actor: event::actor(&saved_user),
+            cwd,
+            command,
+            argv,
+            hydrated: None,
+            matches,
+            hydrate_ms: None,
+            agent,
+        },
+    );
+    Ok(allow_verb(platform))
+}
+
 fn allow(platform: Option<platform::Platform>) -> String {
     match platform {
         Some(platform) => format_allow(&platform),
         None => String::new(),
+    }
+}
+
+fn allow_verb(platform: Option<platform::Platform>) -> String {
+    match platform {
+        Some(platform) => format_allow_verb(&platform),
+        None => "{}".to_string(),
     }
 }
 

--- a/src/pretool/platform.rs
+++ b/src/pretool/platform.rs
@@ -6,12 +6,10 @@ pub(super) enum Platform {
     Cursor,
     ClaudeCode,
     Codex,
-    Pi,
     OpenCode,
 }
 
 const CODEX_ENV: [&str; 2] = ["CODEX_THREAD_ID", "CODEX_SANDBOX"];
-const PI_ENV: [&str; 2] = ["PI_HOME", "PI_CODING_AGENT"];
 const OPENCODE_ENV: [&str; 2] = ["OPENCODE", "OPENCODE_DIR"];
 
 impl Platform {
@@ -20,7 +18,6 @@ impl Platform {
             Platform::Cursor => "cursor",
             Platform::ClaudeCode => "claude",
             Platform::Codex => "codex",
-            Platform::Pi => "pi",
             Platform::OpenCode => "opencode",
         }
     }
@@ -31,7 +28,6 @@ pub(super) fn parse_harness(raw: &str) -> Option<Platform> {
         "cursor" => Some(Platform::Cursor),
         "claude" | "claude-code" | "claudecode" => Some(Platform::ClaudeCode),
         "codex" => Some(Platform::Codex),
-        "pi" => Some(Platform::Pi),
         "opencode" => Some(Platform::OpenCode),
         _ => None,
     }
@@ -44,7 +40,7 @@ pub(super) fn resolve_platform(harness: Option<&str>, input: &Value) -> Option<P
     }
     detect_platform(input).or_else(
         || match input.get("hook_event_name").and_then(Value::as_str) {
-            Some("preToolUse") => Some(Platform::Cursor),
+            Some("preToolUse" | "beforeMCPExecution") => Some(Platform::Cursor),
             Some("PreToolUse") => Some(Platform::ClaudeCode),
             _ => None,
         },
@@ -105,9 +101,6 @@ pub(super) fn detect_platform(input: &Value) -> Option<Platform> {
     if is_opencode(input) {
         return Some(Platform::OpenCode);
     }
-    if is_pi(input) {
-        return Some(Platform::Pi);
-    }
     if env::var("CLAUDE_PROJECT_DIR").is_ok() || is_pretool_use(input) {
         return Some(Platform::ClaudeCode);
     }
@@ -126,18 +119,6 @@ fn is_codex(input: &Value) -> bool {
 /// `turn_id` is Codex-specific. `model` is not: Cursor now sends it too.
 fn is_codex_payload(input: &Value) -> bool {
     is_pretool_use(input) && input.get("turn_id").and_then(Value::as_str).is_some()
-}
-
-fn is_pi(input: &Value) -> bool {
-    PI_ENV.iter().any(|key| env::var(key).is_ok()) || is_pi_payload(input)
-}
-
-fn is_pi_payload(input: &Value) -> bool {
-    is_pretool_use(input)
-        && input
-            .get("tool_name")
-            .and_then(Value::as_str)
-            .is_some_and(|name| name == "bash")
 }
 
 fn is_opencode(input: &Value) -> bool {

--- a/src/pretool/response.rs
+++ b/src/pretool/response.rs
@@ -2,7 +2,7 @@ use super::platform::Platform;
 use serde_json::{Value, json};
 
 /// Wrap the Claude-compatible `hookSpecificOutput` envelope around `fields`.
-/// Codex and Pi use this same PreToolUse rewrite contract.
+/// Codex uses this same PreToolUse rewrite contract.
 fn hook_specific(fields: Value) -> String {
     let mut out = json!({ "hookEventName": "PreToolUse" });
     if let (Some(obj), Some(extra)) = (out.as_object_mut(), fields.as_object()) {
@@ -14,7 +14,14 @@ fn hook_specific(fields: Value) -> String {
 pub(super) fn format_allow(platform: &Platform) -> String {
     match platform {
         Platform::Cursor => json!({"permission": "allow"}).to_string(),
-        Platform::ClaudeCode | Platform::Codex | Platform::Pi | Platform::OpenCode => String::new(),
+        Platform::ClaudeCode | Platform::Codex | Platform::OpenCode => String::new(),
+    }
+}
+
+pub(super) fn format_allow_verb(platform: &Platform) -> String {
+    match platform {
+        Platform::Cursor => json!({"permission": "allow"}).to_string(),
+        Platform::ClaudeCode | Platform::Codex | Platform::OpenCode => "{}".to_string(),
     }
 }
 
@@ -23,7 +30,7 @@ pub(super) fn format_modify(platform: &Platform, tool_input: &Value, new_command
     updated["command"] = json!(new_command);
 
     match platform {
-        Platform::ClaudeCode | Platform::Codex | Platform::Pi => hook_specific(json!({
+        Platform::ClaudeCode | Platform::Codex => hook_specific(json!({
             "permissionDecision": "allow",
             "updatedInput": updated
         })),

--- a/src/pretool/tests/detect.rs
+++ b/src/pretool/tests/detect.rs
@@ -50,23 +50,6 @@ fn test_detect_codex_env() {
 }
 
 #[test]
-fn test_detect_pi_env() {
-    temp_env::with_vars(
-        [
-            ("CURSOR_VERSION", None),
-            ("CLAUDE_PROJECT_DIR", None),
-            ("CODEX_THREAD_ID", None),
-            ("CODEX_HOME", None),
-            ("PI_HOME", Some("/tmp/pi")),
-            ("OPENCODE", None),
-        ],
-        || {
-            assert_eq!(detect_platform(&json!({})), Some(Platform::Pi));
-        },
-    );
-}
-
-#[test]
 fn test_detect_opencode_payload() {
     temp_env::with_vars(AGENT_ENV, || {
         let input = json!({
@@ -82,6 +65,41 @@ fn test_detect_opencode_payload() {
 fn test_detect_unknown_is_none() {
     temp_env::with_vars(AGENT_ENV, || {
         assert_eq!(detect_platform(&json!({})), None);
+    });
+}
+
+#[test]
+fn mcp_verb_without_command_allows_and_does_not_wrap() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config("^engram");
+        let input = r#"{"tool_name":"MCP:mem_stats","mcp_server_name":"engram","hook_event_name":"preToolUse"}"#;
+        let result = handle(&config, input, Audience::Agent, None).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("updated_input"));
+        assert!(!result.contains("--pretool"));
+    });
+}
+
+#[test]
+fn before_mcp_does_not_rewrite_launch_command() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config("^engram");
+        let input = r#"{"hook_event_name":"beforeMCPExecution","tool_name":"MCP:mem_stats","mcp_server_name":"engram","command":"engram"}"#;
+        let result = handle(&config, input, Audience::Agent, None).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("updated_input"));
+        assert!(!result.contains("--pretool"));
+    });
+}
+
+#[test]
+fn post_mcp_event_allows_without_wrap() {
+    with_cursor_env(|| {
+        let (config, _dir) = test_config("^engram");
+        let input = r#"{"hook_event_name":"afterMCPExecution","tool_name":"MCP:mem_stats"}"#;
+        let result = handle(&config, input, Audience::Agent, None).unwrap();
+        assert!(result.contains("allow"));
+        assert!(!result.contains("--pretool"));
     });
 }
 

--- a/src/pretool/tests/wrap.rs
+++ b/src/pretool/tests/wrap.rs
@@ -70,28 +70,6 @@ fn test_match_wraps_codex() {
 }
 
 #[test]
-fn test_match_wraps_pi() {
-    temp_env::with_vars(
-        [
-            ("CURSOR_VERSION", None),
-            ("CLAUDE_PROJECT_DIR", None),
-            ("CODEX_THREAD_ID", None),
-            ("PI_HOME", Some("/tmp/pi")),
-            ("OPENCODE", None),
-        ],
-        || {
-            with_ticket_tmpdir(|| {
-                let (config, _dir) = test_config("^echo");
-                let input = r#"{"tool_name":"bash","tool_input":{"command":"echo hello"},"hook_event_name":"PreToolUse"}"#;
-                let result = handle(&config, input, Audience::Agent, None).unwrap();
-                assert_wraps_with_ticket(&result, "echo hello");
-                assert!(result.contains("updatedInput"));
-            });
-        },
-    );
-}
-
-#[test]
 fn test_claude_no_match_allows_silently() {
     temp_env::with_vars(
         [
@@ -125,7 +103,6 @@ fn test_disclaimer_command_is_rewritten() {
             ("PI_HOME", None),
             ("OPENCODE", None),
             ("LADE_APPROVE", None),
-            ("LADE_DISCLAIMER_APPROVED", None),
         ],
         || {
             with_ticket_tmpdir(|| {

--- a/src/pretool/verb.rs
+++ b/src/pretool/verb.rs
@@ -1,0 +1,229 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+pub(super) fn is_post_event(input: &Value) -> bool {
+    matches!(hook_event(input), Some("afterMCPExecution" | "PostToolUse"))
+}
+
+pub(super) fn is_verb(input: &Value) -> bool {
+    if hook_event(input) == Some("beforeMCPExecution") {
+        return true;
+    }
+    if let Some(name) = tool_name(input)
+        && (name.starts_with("MCP:") || name.starts_with("mcp__"))
+    {
+        return true;
+    }
+    is_opencode_mcp(input)
+}
+
+fn is_opencode_mcp(input: &Value) -> bool {
+    input.get("hook_source").and_then(Value::as_str) == Some("opencode-plugin")
+        && tool_name(input).is_some_and(|name| !name.eq_ignore_ascii_case("bash"))
+}
+
+pub(super) fn hook_event(input: &Value) -> Option<&str> {
+    input.get("hook_event_name").and_then(Value::as_str)
+}
+
+pub(super) fn tool_name(input: &Value) -> Option<&str> {
+    input
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .or_else(|| input.get("tool").and_then(Value::as_str))
+        .filter(|name| !name.is_empty())
+}
+
+pub(super) fn tool_input(input: &Value) -> Option<&Value> {
+    input.get("tool_input").or_else(|| input.get("args"))
+}
+
+pub(super) fn normalize(input: &Value) -> String {
+    verb_prefix(
+        tool_name(input).unwrap_or(""),
+        input.get("mcp_server_name").and_then(Value::as_str),
+    )
+}
+
+pub(super) fn verb_args(input: &Value) -> Option<Value> {
+    let obj = tool_input(input)?.as_object()?;
+    if obj.is_empty() {
+        return None;
+    }
+    let sorted: BTreeMap<&str, &Value> = obj.iter().map(|(key, val)| (key.as_str(), val)).collect();
+    Some(json!(sorted))
+}
+
+fn verb_prefix(tool_name: &str, mcp_server: Option<&str>) -> String {
+    if let Some(rest) = tool_name.strip_prefix("mcp__") {
+        let mut parts = rest.split("__").filter(|part| !part.is_empty());
+        let Some(first) = parts.next() else {
+            return String::new();
+        };
+        let rest: Vec<&str> = parts.collect();
+        if rest.is_empty() {
+            return first.to_string();
+        }
+        return format!("{first}.{}", rest.join("."));
+    }
+    let tool = tool_name.strip_prefix("MCP:").unwrap_or(tool_name);
+    match mcp_server.filter(|server| !server.is_empty()) {
+        Some(server) if !tool.is_empty() => format!("{server}.{tool}"),
+        _ => tool.to_string(),
+    }
+}
+
+pub(super) fn verb_agent(mut base: Value, input: &Value) -> Value {
+    let obj = match base.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            base = json!({});
+            base.as_object_mut().expect("object")
+        }
+    };
+    if let Some((server, tool)) = verb_parts(input) {
+        if let Some(tool) = tool {
+            obj.insert("tool".to_string(), json!(tool));
+        }
+        if let Some(server) = server {
+            obj.insert("mcp_server".to_string(), json!(server));
+        }
+    }
+    if let Some(event) = hook_event(input) {
+        obj.insert("hook".to_string(), json!(event));
+    }
+    if let Some(id) = input.get("tool_use_id").and_then(Value::as_str)
+        && !id.is_empty()
+    {
+        obj.insert("tool_use_id".to_string(), json!(id));
+    }
+    if hook_event(input) == Some("beforeMCPExecution")
+        && let Some(launch) = launch_from(input)
+    {
+        obj.insert("launch".to_string(), json!(launch));
+    }
+    if obj.is_empty() { Value::Null } else { base }
+}
+
+fn verb_parts(input: &Value) -> Option<(Option<String>, Option<String>)> {
+    let prefix = verb_prefix(
+        tool_name(input).unwrap_or(""),
+        input.get("mcp_server_name").and_then(Value::as_str),
+    );
+    if prefix.is_empty() {
+        return None;
+    }
+    match prefix.split_once('.') {
+        Some((server, tool)) => Some((Some(server.to_string()), Some(tool.to_string()))),
+        None => Some((None, Some(prefix))),
+    }
+}
+
+fn launch_from(input: &Value) -> Option<String> {
+    input
+        .get("command")
+        .and_then(Value::as_str)
+        .or_else(|| input.get("url").and_then(Value::as_str))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_prefixes_and_before_mcp() {
+        assert!(is_verb(&json!({"tool_name":"MCP:mem_stats"})));
+        assert!(is_verb(&json!({"tool_name":"mcp__engram__mem_stats"})));
+        assert!(is_verb(
+            &json!({"hook_event_name":"beforeMCPExecution","command":"engram"})
+        ));
+        assert!(!is_verb(
+            &json!({"tool_name":"Shell","tool_input":{"command":"echo"}})
+        ));
+        assert!(is_post_event(&json!({"hook_event_name":"PostToolUse"})));
+        assert!(is_post_event(
+            &json!({"hook_event_name":"afterMCPExecution"})
+        ));
+    }
+
+    #[test]
+    fn normalize_table() {
+        assert_eq!(
+            normalize(&json!({
+                "tool_name":"MCP:mem_stats",
+                "mcp_server_name":"engram"
+            })),
+            "engram.mem_stats"
+        );
+        assert_eq!(
+            normalize(&json!({
+                "tool_name":"mem_stats",
+                "mcp_server_name":"engram"
+            })),
+            "engram.mem_stats"
+        );
+        assert_eq!(
+            normalize(&json!({"tool_name":"MCP:mem_stats"})),
+            "mem_stats"
+        );
+        assert_eq!(
+            normalize(&json!({"tool_name":"mcp__engram__mem_stats"})),
+            "engram.mem_stats"
+        );
+        assert_eq!(
+            normalize(&json!({"tool_name":"mcp__engram__foo__bar"})),
+            "engram.foo.bar"
+        );
+        assert_eq!(
+            normalize(&json!({"tool_name":"mcp__mem_stats"})),
+            "mem_stats"
+        );
+        assert_eq!(
+            normalize(&json!({
+                "tool_name":"MCP:mem_stats",
+                "mcp_server_name":"engram",
+                "tool_input":{"project":"lade","z":1}
+            })),
+            "engram.mem_stats"
+        );
+        assert_eq!(
+            verb_args(&json!({
+                "tool_name":"MCP:mem_stats",
+                "mcp_server_name":"engram",
+                "tool_input":{"project":"lade","z":1}
+            })),
+            Some(json!({"project":"lade","z":1}))
+        );
+        assert_eq!(
+            normalize(&json!({
+                "tool_name":"MCP:mem_stats",
+                "mcp_server_name":"engram",
+                "tool_input":{}
+            })),
+            "engram.mem_stats"
+        );
+        assert_eq!(
+            verb_args(&json!({
+                "tool_name":"MCP:mem_stats",
+                "mcp_server_name":"engram",
+                "tool_input":{}
+            })),
+            None
+        );
+    }
+
+    #[test]
+    fn opencode_single_token_is_a_verb() {
+        let input = json!({
+            "hook_source":"opencode-plugin",
+            "tool":"mem_stats",
+            "args":{"project":"lade"}
+        });
+        assert!(is_verb(&input));
+        assert_eq!(normalize(&input), "mem_stats");
+        assert_eq!(verb_args(&input), Some(json!({"project":"lade"})));
+    }
+}

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 
+use serde_json::Value;
+
 use crate::pretool::split_command_env_prefix;
 use crate::redact::Redactor;
 
@@ -25,7 +27,6 @@ const PREFIXES: &[&str] = &[
 
 pub struct Redacted {
     pub command: String,
-    pub truncated: bool,
 }
 
 /// Redact a command for the diary. `hydrated` is every public value on
@@ -40,17 +41,152 @@ pub fn redact_command(raw: &str, hydrated: Option<&HashMap<String, String>>) -> 
         {
             return Redacted {
                 command: String::new(),
-                truncated: false,
             };
         }
     }
-    let truncated = command.chars().count() > CAP;
-    if truncated {
-        command = command.chars().take(CAP).collect();
-    }
     command = apply_context_needles(&command);
     command = apply_prefix_and_length(&command);
-    Redacted { command, truncated }
+    Redacted { command }
+}
+
+pub fn peel_command(line: &str) -> (String, Option<Value>) {
+    let tokens = tokenize(line);
+    match tokens.as_slice() {
+        [] => (String::new(), None),
+        [command] => (command.clone(), None),
+        [command, rest @ ..] => (
+            command.clone(),
+            Some(Value::Array(
+                rest.iter().cloned().map(Value::String).collect(),
+            )),
+        ),
+    }
+}
+
+pub fn cap_text(text: String) -> (String, bool) {
+    let truncated = text.chars().count() > CAP;
+    if truncated {
+        (text.chars().take(CAP).collect(), true)
+    } else {
+        (text, false)
+    }
+}
+
+fn tokenize(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quote = None;
+    for ch in line.chars() {
+        match (quote, ch) {
+            (None, '\'') | (None, '"') => quote = Some(ch),
+            (Some(q), c) if c == q => quote = None,
+            (None, c) if c.is_whitespace() => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            (_, c) => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+pub fn redact_argv(
+    value: Option<Value>,
+    hydrated: Option<&HashMap<String, String>>,
+) -> Option<Value> {
+    let mut value = value?;
+    if value.is_null() {
+        return None;
+    }
+    if let Some(values) = hydrated {
+        replace_known_in_json(&mut value, values);
+        if json_contains_hydrate(&value, values) {
+            return None;
+        }
+    }
+    walk_scrub(&mut value);
+    cap_json(&mut value);
+    match &value {
+        Value::Null => None,
+        Value::Object(map) if map.is_empty() => None,
+        Value::Array(items) if items.is_empty() => None,
+        _ => Some(value),
+    }
+}
+
+fn replace_known_in_json(value: &mut Value, hydrated: &HashMap<String, String>) {
+    match value {
+        Value::String(text) => *text = replace_known_values(text, hydrated),
+        Value::Array(items) => {
+            for item in items {
+                replace_known_in_json(item, hydrated);
+            }
+        }
+        Value::Object(map) => {
+            for item in map.values_mut() {
+                replace_known_in_json(item, hydrated);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_contains_hydrate(value: &Value, hydrated: &HashMap<String, String>) -> bool {
+    match value {
+        Value::String(text) => hydrated
+            .values()
+            .any(|secret| !secret.is_empty() && text.contains(secret.as_str())),
+        Value::Array(items) => items
+            .iter()
+            .any(|item| json_contains_hydrate(item, hydrated)),
+        Value::Object(map) => map
+            .values()
+            .any(|item| json_contains_hydrate(item, hydrated)),
+        _ => false,
+    }
+}
+
+fn walk_scrub(value: &mut Value) {
+    match value {
+        Value::String(text) => {
+            *text = apply_context_needles(text);
+            *text = apply_prefix_and_length(text);
+        }
+        Value::Array(items) => {
+            for item in items {
+                walk_scrub(item);
+            }
+        }
+        Value::Object(map) => {
+            for item in map.values_mut() {
+                walk_scrub(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn cap_json(value: &mut Value) {
+    match value {
+        Value::String(text) if text.chars().count() > CAP => {
+            *text = text.chars().take(CAP).collect();
+        }
+        Value::Array(items) => {
+            for item in items {
+                cap_json(item);
+            }
+        }
+        Value::Object(map) => {
+            for item in map.values_mut() {
+                cap_json(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn replace_known_values(command: &str, values: &HashMap<String, String>) -> String {
@@ -196,6 +332,7 @@ fn prefix_or_len_hit(tok: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     const SECRET: &str = "tok_example_0000000001";
     const OTHER: &str = "other_example_0000000002";
@@ -305,15 +442,31 @@ mod tests {
         values.insert("API_TOKEN".into(), "API".into());
         let out = redact_command("echo API", Some(&values));
         assert_eq!(out.command, "");
-        assert!(!out.truncated);
     }
 
     #[test]
     fn cap_1024_sets_truncated() {
         let raw: String = "a".repeat(1025);
-        let out = redact_command(&raw, None);
-        assert_eq!(out.command.chars().count(), 1024);
-        assert!(out.truncated);
+        let (out, truncated) = cap_text(raw);
+        assert_eq!(out.chars().count(), 1024);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn peel_command_splits_like_docker() {
+        assert_eq!(
+            peel_command("npm run deploy"),
+            ("npm".into(), Some(json!(["run", "deploy"])))
+        );
+        assert_eq!(
+            peel_command(r#"echo hello | grep foo"#),
+            ("echo".into(), Some(json!(["hello", "|", "grep", "foo"])))
+        );
+        assert_eq!(
+            peel_command(r#"sh -c "echo hello | grep foo""#),
+            ("sh".into(), Some(json!(["-c", "echo hello | grep foo"])))
+        );
+        assert_eq!(peel_command("ls"), ("ls".into(), None));
     }
 
     #[test]
@@ -324,5 +477,26 @@ mod tests {
         let auth = seen(r#"curl -H "Authorization: basic hunter2""#);
         assert!(auth.contains("Authorization: basic ?"), "{auth}");
         assert!(!auth.contains("hunter2"), "{auth}");
+    }
+
+    #[test]
+    fn json_args_are_scrubbed_and_capped() {
+        let sha = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+        let out = redact_argv(Some(json!({"token": sha, "ok": "lade"})), None).unwrap();
+        assert_eq!(out["token"], "?");
+        assert_eq!(out["ok"], "lade");
+        let huge = "a".repeat(2000);
+        let capped = redact_argv(Some(json!({"z": huge, "a": "keep"})), None).unwrap();
+        assert_eq!(capped["z"].as_str().unwrap().chars().count(), 1024);
+        assert_eq!(capped["a"], "keep");
+    }
+
+    #[test]
+    fn argv_hydrate_leftover_drops_column() {
+        let mut values = HashMap::new();
+        values.insert("API_TOKEN".into(), "API".into());
+        assert!(redact_argv(Some(json!(["echo", "API"])), Some(&values)).is_none());
+        let kept = redact_argv(Some(json!(["engram", "--stdio"])), None).unwrap();
+        assert_eq!(kept, json!(["engram", "--stdio"]));
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -8,32 +8,13 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
-pub const LADE_PENDING: &str = "LADE_PENDING";
-pub const LADE_DISCLAIMER_APPROVED: &str = "LADE_DISCLAIMER_APPROVED";
 pub const LADE_APPROVE: &str = "LADE_APPROVE";
-pub const LADE_NETWORK_PIDS: &str = "LADE_NETWORK_PIDS";
 pub const LADE_RESTORE: &str = "LADE_RESTORE";
 pub const LADE_VIA: &str = "LADE_VIA";
 pub const LADE_T: &str = "LADE_T";
 
 /// Protocol env the child must not inherit. `LADE_APPROVE` stays.
-/// Stale names stay here so an upgraded binary still strips leftovers.
-pub const CHILD_UNSET: [&str; 6] = [
-    LADE_VIA,
-    LADE_T,
-    LADE_PENDING,
-    LADE_RESTORE,
-    LADE_NETWORK_PIDS,
-    LADE_DISCLAIMER_APPROVED,
-];
-
-/// Dropped protocol keys. `set` / `unset` still clear them in the shell.
-pub const STALE_UNSET: [&str; 4] = [
-    LADE_PENDING,
-    LADE_NETWORK_PIDS,
-    LADE_VIA,
-    LADE_DISCLAIMER_APPROVED,
-];
+pub const CHILD_UNSET: [&str; 3] = [LADE_VIA, LADE_T, LADE_RESTORE];
 
 pub fn strip_child_protocol(cmd: &mut std::process::Command) {
     for key in CHILD_UNSET {

--- a/src/status/gather.rs
+++ b/src/status/gather.rs
@@ -65,6 +65,7 @@ pub(super) async fn gather(opts: &StatusCommand) -> Result<StatusReport> {
         },
         pretool: pretool::install::inspect(&cwd)?,
     };
+    let skills = pretool::install::inspect_skills(&cwd)?;
 
     let saved_user = global.user.or_else(|| {
         std::env::var("USER")
@@ -128,6 +129,7 @@ pub(super) async fn gather(opts: &StatusCommand) -> Result<StatusReport> {
         version,
         global_config,
         hooks,
+        skills,
         project_config,
         log: event::info(),
         ok,

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -69,6 +69,7 @@ struct StatusReport {
     version: VersionInfo,
     global_config: GlobalConfigInfo,
     hooks: HooksInfo,
+    skills: crate::pretool::install::SkillsStatus,
     project_config: ProjectConfig,
     log: event::LogInfo,
     ok: bool,

--- a/src/status/print.rs
+++ b/src/status/print.rs
@@ -53,10 +53,18 @@ pub(super) fn print_human(report: &StatusReport) {
     print_pretool_line("Claude Code project", &report.hooks.pretool.claude.project);
     print_pretool_line("Codex global", &report.hooks.pretool.codex.global);
     print_pretool_line("Codex project", &report.hooks.pretool.codex.project);
-    print_pretool_line("Pi global", &report.hooks.pretool.pi.global);
-    print_pretool_line("Pi project", &report.hooks.pretool.pi.project);
     print_pretool_line("OpenCode global", &report.hooks.pretool.opencode.global);
     print_pretool_line("OpenCode project", &report.hooks.pretool.opencode.project);
+
+    println!("skills");
+    print_pretool_line("Cursor global", &report.skills.cursor.global);
+    print_pretool_line("Cursor project", &report.skills.cursor.project);
+    print_pretool_line("Claude Code global", &report.skills.claude.global);
+    print_pretool_line("Claude Code project", &report.skills.claude.project);
+    print_pretool_line("Codex global", &report.skills.codex.global);
+    print_pretool_line("Codex project", &report.skills.codex.project);
+    print_pretool_line("OpenCode global", &report.skills.opencode.global);
+    print_pretool_line("OpenCode project", &report.skills.opencode.project);
 
     let pc = &report.project_config;
     println!(

--- a/src/ticket/tests.rs
+++ b/src/ticket/tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 use serde_json::json;
+use std::sync::{Mutex, OnceLock};
+
+fn ticket_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_ticket_dir(f: impl FnOnce()) {
+    let _guard = ticket_env_lock().lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    temp_env::with_var("LADE_TICKET_DIR", Some(tmp.path().to_str().unwrap()), f);
+}
 
 fn sample_pre_event() -> PreEvent {
     PreEvent {
@@ -58,45 +70,47 @@ fn peel_pretool_equals_form() {
 
 #[test]
 fn peel_pretool_space_form() {
-    fs::create_dir_all(dir()).unwrap();
-    fs::write(path("x7Km"), "{}").unwrap();
-    let (id, argv) = peel_pretool(vec![
-        OsString::from("lade"),
-        OsString::from("--pretool"),
-        OsString::from("x7Km"),
-        OsString::from("echo"),
-    ]);
-    unlink("x7Km").unwrap();
-    assert_eq!(id.as_deref(), Some("x7Km"));
-    assert_eq!(
-        argv,
-        vec![
+    with_ticket_dir(|| {
+        fs::write(path("x7Km"), "{}").unwrap();
+        let (id, argv) = peel_pretool(vec![
             OsString::from("lade"),
             OsString::from("--pretool"),
+            OsString::from("x7Km"),
             OsString::from("echo"),
-        ]
-    );
+        ]);
+        unlink("x7Km").unwrap();
+        assert_eq!(id.as_deref(), Some("x7Km"));
+        assert_eq!(
+            argv,
+            vec![
+                OsString::from("lade"),
+                OsString::from("--pretool"),
+                OsString::from("echo"),
+            ]
+        );
+    });
 }
 
 #[test]
 fn peel_pretool_does_not_consume_echo_without_file() {
-    let _ = unlink("echo");
-    let (id, argv) = peel_pretool(vec![
-        OsString::from("lade"),
-        OsString::from("--pretool"),
-        OsString::from("echo"),
-        OsString::from("hi"),
-    ]);
-    assert!(id.is_none());
-    assert_eq!(
-        argv,
-        vec![
+    with_ticket_dir(|| {
+        let (id, argv) = peel_pretool(vec![
             OsString::from("lade"),
             OsString::from("--pretool"),
             OsString::from("echo"),
             OsString::from("hi"),
-        ]
-    );
+        ]);
+        assert!(id.is_none());
+        assert_eq!(
+            argv,
+            vec![
+                OsString::from("lade"),
+                OsString::from("--pretool"),
+                OsString::from("echo"),
+                OsString::from("hi"),
+            ]
+        );
+    });
 }
 
 #[test]
@@ -121,9 +135,7 @@ fn peel_pretool_does_not_consume_inject() {
 
 #[test]
 fn write_twice_in_one_ms_does_not_spin() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().to_str().unwrap();
-    temp_env::with_var("LADE_TICKET_DIR", Some(path), || {
+    with_ticket_dir(|| {
         let pre = sample_pre_event();
         let mut ids = std::collections::HashSet::new();
         for _ in 0..16 {
@@ -137,29 +149,21 @@ fn write_twice_in_one_ms_does_not_spin() {
 
 #[test]
 fn write_read_unlink_roundtrip() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path = tmp.path().to_str().unwrap();
-    temp_env::with_var("LADE_TICKET_DIR", Some(path), || {
-        write_read_unlink_roundtrip_inner();
+    with_ticket_dir(|| {
+        let pre = sample_pre_event();
+        let id = write(&pre).expect("write ticket");
+        assert!(is_id(&id));
+        let read_back = read(&id).expect("read ticket");
+        assert_eq!(read_back, pre);
+        unlink(&id).expect("unlink ticket");
+        assert!(!path(&id).exists());
+        unlink(&id).expect("unlink missing is ok");
     });
-}
-
-fn write_read_unlink_roundtrip_inner() {
-    let pre = sample_pre_event();
-    let id = write(&pre).expect("write ticket");
-    assert!(is_id(&id));
-    let read_back = read(&id).expect("read ticket");
-    assert_eq!(read_back, pre);
-    unlink(&id).expect("unlink ticket");
-    assert!(!path(&id).exists());
-    unlink(&id).expect("unlink missing is ok");
 }
 
 #[test]
 fn replace_updates_same_id() {
-    let tmp = tempfile::tempdir().unwrap();
-    let dir = tmp.path().to_str().unwrap();
-    temp_env::with_var("LADE_TICKET_DIR", Some(dir), || {
+    with_ticket_dir(|| {
         let mut pre = sample_pre_event();
         let id = write(&pre).unwrap();
         pre.pending = true;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -49,10 +49,25 @@ pub fn log_rows(home: &Path, dir: &Path) -> serde_json::Value {
 
 #[allow(dead_code)]
 pub fn stored_command(home: &Path, dir: &Path) -> String {
-    log_rows(home, dir)[0]["command"]
-        .as_str()
-        .unwrap()
-        .to_string()
+    row_line(&log_rows(home, dir)[0])
+}
+
+pub fn row_line(row: &serde_json::Value) -> String {
+    let command = row["command"].as_str().unwrap_or("");
+    match &row["argv"] {
+        serde_json::Value::Array(items) if !items.is_empty() => {
+            let rest: Vec<&str> = items.iter().filter_map(|item| item.as_str()).collect();
+            if rest.is_empty() {
+                command.to_string()
+            } else {
+                format!("{} {}", command, rest.join(" "))
+            }
+        }
+        serde_json::Value::Object(map) if !map.is_empty() => {
+            format!("{command} {}", row["argv"])
+        }
+        _ => command.to_string(),
+    }
 }
 
 #[allow(dead_code)]
@@ -158,11 +173,17 @@ pub fn lade_std(home: &Path) -> StdCommand {
         .unwrap();
     }
     let mut cmd = StdCommand::new(assert_cmd::cargo::cargo_bin("lade"));
+    // Drop leftover preexec protocol from the developer shell. An inherited
+    // LADE_T would replay a ticket (often the repo `.` catch-all) and skip
+    // the temp lade.yml the test just wrote.
     cmd.env("LADE_SHELL", "bash")
         .env("HOME", home)
         .env("LADE_CONFIG_PATH", config_path)
         .env("LADE_EVENTS_PATH", home.join("events.db"))
         .env_remove("LADE_VIA")
+        .env_remove("LADE_T")
+        .env_remove("LADE_RESTORE")
+        .env_remove("LADE_APPROVE")
         .env_remove("AI_AGENT")
         .env_remove("AGENT")
         .env_remove("CLAUDECODE")

--- a/tests/disclaimer.rs
+++ b/tests/disclaimer.rs
@@ -36,7 +36,7 @@ fn test_disclaimer_hook_flow() {
     assert!(!out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stdout.contains("unset -v LADE_PENDING"));
+    assert!(stdout.contains("unset -v LADE_RESTORE"));
     assert!(stdout.contains("export LADE_T='"));
     assert!(!stdout.contains("export LADE_PENDING='"));
     assert!(stderr.contains("Disclaimer required to uncover the secrets"));
@@ -57,6 +57,7 @@ fn test_disclaimer_hook_flow() {
     // 3. a wrong code (including the old `1` reflex) stays blocked
     common::lade(home.path())
         .current_dir(dir.path())
+        .env("LADE_TICKET_DIR", tickets.path())
         .env("LADE_APPROVE", "1")
         .args(["set", "deploy"])
         .assert()

--- a/tests/log_emit.rs
+++ b/tests/log_emit.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{SECRET, inject, log_rows, write_yml, write_yml_raw};
+use common::{SECRET, inject, log_rows, row_line, write_yml, write_yml_raw};
 use std::fs;
 use std::thread;
 use tempfile::tempdir;
@@ -21,7 +21,7 @@ fn disclaimer_denied_writes_kind() {
     let rows = log_rows(home.path(), dir.path());
     assert_eq!(rows.as_array().unwrap().len(), 1);
     assert_eq!(rows[0]["kind"], "denied");
-    assert_eq!(rows[0]["command"], "echo hi");
+    assert_eq!(row_line(&rows[0]), "echo hi");
     assert!(rows[0]["hydrate_ms"].is_null());
     let matches = rows[0]["matches"].as_array().unwrap();
     assert_eq!(matches[0]["rule"], "^echo");
@@ -105,7 +105,7 @@ fn set_emits_seen_without_event_id() {
     let rows = log_rows(home.path(), dir.path());
     assert_eq!(rows[0]["kind"], "seen");
     assert_eq!(rows[0]["via"], "preexec");
-    assert_eq!(rows[0]["command"], "echo hi");
+    assert_eq!(row_line(&rows[0]), "echo hi");
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn hook_match_is_silent_inject_writes() {
     assert_eq!(rows[0]["kind"], "access");
     assert_eq!(rows[0]["via"], "pretool");
     assert_eq!(rows[0]["audience"], "agent");
-    assert_eq!(rows[0]["command"], "echo hi");
+    assert_eq!(row_line(&rows[0]), "echo hi");
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn hook_no_match_walk_log_writes_seen() {
     let rows = log_rows(home.path(), dir.path());
     assert_eq!(rows[0]["kind"], "seen");
     assert_eq!(rows[0]["via"], "pretool");
-    assert_eq!(rows[0]["command"], "echo hi");
+    assert_eq!(row_line(&rows[0]), "echo hi");
     assert_eq!(rows[0]["agent"]["harness"], "cursor");
     assert_eq!(rows[0]["agent"]["session"], "conv_1");
 }
@@ -229,7 +229,7 @@ fn dot_log_then_later_secret_is_access() {
     inject(home.path(), dir.path(), &["echo", SECRET]);
     let rows = log_rows(home.path(), dir.path());
     assert_eq!(rows[0]["kind"], "access");
-    let cmd = rows[0]["command"].as_str().unwrap();
+    let cmd = row_line(&rows[0]);
     assert!(cmd.contains("${API_TOKEN}"), "{cmd}");
     assert!(!cmd.contains(SECRET), "{cmd}");
 }
@@ -245,7 +245,7 @@ fn child_secrets_inherit_parent_dot_log() {
     inject(home.path(), &child, &["echo", SECRET]);
     let rows = log_rows(home.path(), &child);
     assert_eq!(rows[0]["kind"], "access");
-    let cmd = rows[0]["command"].as_str().unwrap();
+    let cmd = row_line(&rows[0]);
     assert!(cmd.contains("${API_TOKEN}"), "{cmd}");
 }
 
@@ -264,15 +264,10 @@ fn overlay_log_parent_then_child() {
     inject(home.path(), &child, &["git", "status"]);
     inject(home.path(), &child, &["npm", "run", "deploy"]);
     let rows = log_rows(home.path(), &child);
-    let cmds: Vec<&str> = rows
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|r| r["command"].as_str().unwrap())
-        .collect();
-    assert!(cmds.contains(&"echo hi"), "{cmds:?}");
+    let cmds: Vec<String> = rows.as_array().unwrap().iter().map(row_line).collect();
+    assert!(cmds.iter().any(|c| c == "echo hi"), "{cmds:?}");
     assert!(!cmds.iter().any(|c| c.contains("git status")), "{cmds:?}");
-    assert!(cmds.contains(&"npm run deploy"), "{cmds:?}");
+    assert!(cmds.iter().any(|c| c == "npm run deploy"), "{cmds:?}");
 }
 
 #[test]

--- a/tests/log_query.rs
+++ b/tests/log_query.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::{SECRET, filter_log, init_git, inject, log_rows, write_yml};
+use common::{SECRET, filter_log, init_git, inject, log_rows, row_line, write_yml};
 use std::fs;
 use tempfile::tempdir;
 
@@ -287,12 +287,9 @@ fn usage_and_log_all_reads_every_repo() {
         .stdout
         .clone();
     let rows: Vec<serde_json::Value> = serde_json::from_slice(&log).unwrap();
-    let cmds: Vec<&str> = rows
-        .iter()
-        .map(|r| r["command"].as_str().unwrap())
-        .collect();
-    assert!(cmds.contains(&"echo a"), "{cmds:?}");
-    assert!(cmds.contains(&"echo b"), "{cmds:?}");
+    let cmds: Vec<String> = rows.iter().map(row_line).collect();
+    assert!(cmds.iter().any(|c| c == "echo a"), "{cmds:?}");
+    assert!(cmds.iter().any(|c| c == "echo b"), "{cmds:?}");
 }
 
 #[test]
@@ -341,5 +338,5 @@ fn usage_and_log_path_scopes_to_that_root() {
         .clone();
     let rows: Vec<serde_json::Value> = serde_json::from_slice(&log).unwrap();
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["command"], "echo b");
+    assert_eq!(row_line(&rows[0]), "echo b");
 }

--- a/tests/log_redact.rs
+++ b/tests/log_redact.rs
@@ -33,7 +33,7 @@ fn inject_seen_does_not_store_secret() {
         ],
     );
     let rows = log_rows(home.path(), dir.path());
-    let cmd = rows[0]["command"].as_str().unwrap();
+    let cmd = stored_command(home.path(), dir.path());
     assert!(cmd.contains("Authorization: Bearer ?"), "{cmd}");
     assert!(!cmd.contains(SECRET), "{cmd}");
     assert_eq!(rows[0]["kind"], "seen");
@@ -161,7 +161,7 @@ fn access_hydrate_replaces_name() {
     );
     inject(home.path(), dir.path(), &["echo", SECRET]);
     let rows = log_rows(home.path(), dir.path());
-    let cmd = rows[0]["command"].as_str().unwrap();
+    let cmd = stored_command(home.path(), dir.path());
     assert!(cmd.contains("${API_TOKEN}"), "{cmd}");
     assert!(!cmd.contains(SECRET), "{cmd}");
     assert_eq!(rows[0]["kind"], "access");

--- a/tests/log_source.rs
+++ b/tests/log_source.rs
@@ -1,6 +1,7 @@
 mod common;
 use common::{
-    backdate_all, filter_log, inject, lade_user, leftover_src_dirs_in, share_pack, write_yml,
+    backdate_all, filter_log, inject, lade_user, leftover_src_dirs_in, row_line, share_pack,
+    write_yml,
 };
 use std::fs;
 use tempfile::tempdir;
@@ -142,12 +143,9 @@ fn source_pack_excludes_later_live_rows() {
         dir.path(),
         &["--source", pack.to_str().unwrap()],
     );
-    let cmds: Vec<&str> = packed
-        .iter()
-        .map(|r| r["command"].as_str().unwrap())
-        .collect();
-    assert!(cmds.contains(&"echo packed"), "{cmds:?}");
-    assert!(!cmds.contains(&"echo live-only"), "{cmds:?}");
+    let cmds: Vec<String> = packed.iter().map(row_line).collect();
+    assert!(cmds.iter().any(|c| c == "echo packed"), "{cmds:?}");
+    assert!(!cmds.iter().any(|c| c == "echo live-only"), "{cmds:?}");
 }
 
 #[test]
@@ -181,7 +179,7 @@ fn source_since_filters_packed_window() {
         .clone();
     let all: Vec<serde_json::Value> = serde_json::from_slice(&out).unwrap();
     assert_eq!(all.len(), 1);
-    assert_eq!(all[0]["command"], "echo old");
+    assert_eq!(row_line(&all[0]), "echo old");
 }
 
 #[test]
@@ -261,9 +259,6 @@ fn source_directory_is_not_recursive() {
         dir.path(),
         &["--source", packs.to_str().unwrap()],
     );
-    let cmds: Vec<&str> = rows
-        .iter()
-        .map(|r| r["command"].as_str().unwrap())
-        .collect();
-    assert_eq!(cmds, vec!["echo top"]);
+    let cmds: Vec<String> = rows.iter().map(row_line).collect();
+    assert_eq!(cmds, vec!["echo top".to_string()]);
 }

--- a/tests/mcp.rs
+++ b/tests/mcp.rs
@@ -74,7 +74,7 @@ fn test_mcp_agent_when_uses_env_signal() {
         .args(["mcp", "--", "env"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("PUBLIC=agentsecret").not());
+        .stdout(predicates::str::contains("PUBLIC=agentsecret"));
     common::lade(home.path())
         .current_dir(dir.path())
         .env("CURSOR_AGENT", "1")

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -52,14 +52,16 @@ fn test_status_json_is_valid_with_expected_keys() {
     assert!(value["hooks"]["pretool"].get("cursor").is_some());
     assert!(value["hooks"]["pretool"].get("claude").is_some());
     assert!(value["hooks"]["pretool"].get("codex").is_some());
-    assert!(value["hooks"]["pretool"].get("pi").is_some());
     assert!(value["hooks"]["pretool"].get("opencode").is_some());
+    assert!(value["hooks"]["pretool"].get("pi").is_none());
     assert!(value.get("project_config").is_some());
     assert!(value.get("ok").is_some());
     assert_eq!(
         value["hooks"]["preexec"]["inject_skips_startup_files"],
         true
     );
+    assert!(value.get("skills").is_some());
+    assert!(value["skills"].get("cursor").is_some());
     assert!(value.get("log").is_some());
     assert!(value["log"].get("path").is_some());
     assert_eq!(value["log"]["events"], 0);


### PR DESCRIPTION
## Summary
- MCP `tools/call` (beforeMCPExecution, `MCP:`, `mcp__`, OpenCode plugin) become diary `seen` rows with `via=mcp`. No rewrite, no hydrate.
- `command` is argv0. `argv` is JSONB: a string array for shell and `lade mcp` rest tokens, an object for a verb.
- Skills are Lade-managed when the whole `SKILL.md` sha256 matches the bundled file or a previous official hash. Pi install is dropped. Internal commands stay hidden unless `--help -v`.

## Test plan
- [ ] `cargo test --workspace --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] MCP verb in Cursor or Claude: one row per `tool_use_id`, `command` is `server.tool`
- [ ] `lade log` prints the reconstructed line; `lade log --group command` counts argv0
- [ ] `lade mcp -- …` stores the spawn target, not `lade mcp --`