### PR TITLE
feat: add age-plugin-lade so age can load Lade secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,9 @@ jobs:
         shell: bash
         run: |
           mv "target/${{ matrix.target }}/release/lade${{ matrix.suffix }}" .
+          mv "target/${{ matrix.target }}/release/age-plugin-lade${{ matrix.suffix }}" .
           asset="lade-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
-          tar czvf "$asset" "lade${{ matrix.suffix }}"
+          tar czvf "$asset" "lade${{ matrix.suffix }}" "age-plugin-lade${{ matrix.suffix }}"
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$asset" > "$asset.sha256"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,27 +56,21 @@ jobs:
         include:
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            suffix: ""
             build_cmd: cargo
           - os: macos-15
             target: aarch64-apple-darwin
-            suffix: ""
             build_cmd: cargo
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            suffix: ""
             build_cmd: cross
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
-            suffix: ""
             build_cmd: cross
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
-            suffix: ""
             build_cmd: cross
           - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-            suffix: ""
             build_cmd: cross
     steps:
       - uses: actions/checkout@v7
@@ -94,10 +88,10 @@ jobs:
       - name: Compress
         shell: bash
         run: |
-          mv "target/${{ matrix.target }}/release/lade${{ matrix.suffix }}" .
-          mv "target/${{ matrix.target }}/release/age-plugin-lade${{ matrix.suffix }}" .
+          mv "target/${{ matrix.target }}/release/lade" .
+          mv "target/${{ matrix.target }}/release/age-plugin-lade" .
           asset="lade-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
-          tar czvf "$asset" "lade${{ matrix.suffix }}" "age-plugin-lade${{ matrix.suffix }}"
+          tar czvf "$asset" lade age-plugin-lade
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$asset" > "$asset.sha256"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Release notes are also published on [GitHub Releases](https://github.com/zifeo/l
 
 ## [Unreleased]
 
+### Added
+
+- **age plugin**: Cargo builds `lade` and `age-plugin-lade` from the
+  same `main`. The release tarball, installer, image, and
+  `cargo install` ship both files. `lade upgrade` copies the new
+  `lade` over the plugin name because self_update extracts one
+  binary. age and rage resolve a Lade URI the same way `lade eval`
+  does, then wrap or unwrap with the age crate (X25519, SSH, tagged,
+  and post-quantum `age1tagpq1` recipients). `lade eval` and the
+  plugin write an `access` diary row (URI only, never the value).
+
 ### Fixed
 
 - **Installer during a release**: GitHub `latest` stays on the previous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "age"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "age-core",
+ "base64 0.22.1",
+ "bcrypt-pbkdf",
+ "bech32",
+ "cbc",
+ "chacha20poly1305",
+ "cipher",
+ "cookie-factory",
+ "ctr",
+ "curve25519-dalek",
+ "hkdf",
+ "hmac",
+ "hpke",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "ml-kem",
+ "nom",
+ "num-traits",
+ "p256",
+ "pin-project",
+ "rand 0.8.8",
+ "rsa",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "sha3",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
+dependencies = [
+ "base64 0.22.1",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "hpke",
+ "io_tee",
+ "nom",
+ "rand 0.8.8",
+ "secrecy",
+ "sha2 0.10.9",
+ "tempfile",
+]
+
+[[package]]
+name = "age-plugin"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e639a0bf4973247c88bc8ff08517f0ee438d19ba3d40f6f340353c6ba9fc2aa"
+dependencies = [
+ "age-core",
+ "base64 0.22.1",
+ "bech32",
+ "chrono",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +309,32 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bit-set"
@@ -230,7 +378,26 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.14",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -269,6 +436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +470,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
@@ -301,6 +488,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -342,6 +542,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -475,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
+
+[[package]]
 name = "cookie_store"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,12 +822,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -617,7 +850,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.4.14",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -675,7 +917,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -707,7 +949,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -809,6 +1053,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +1164,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1187,15 @@ checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -940,6 +1222,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash",
+ "self_cell",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1065,6 +1392,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1092,6 +1420,27 @@ dependencies = [
  "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1170,6 +1519,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hpke"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "p256",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1594,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -1274,6 +1670,72 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602e6bd30c3db2749e13e38b363a3d98d9d41de1d8de7a79c31bb69e45b47cda"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1430,6 +1892,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
+
+[[package]]
 name = "ipnet"
 version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,7 +2010,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1572,9 +2069,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "lade"
 version = "0.18.0"
 dependencies = [
+ "age",
+ "age-core",
+ "age-plugin",
  "aho-corasick",
  "anyhow",
  "assert_cmd",
@@ -1638,9 +2157,18 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
- "toml",
+ "toml 1.1.5+spec-1.1.0",
  "url",
  "urlencoding",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1648,6 +2176,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1715,6 +2249,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +2286,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,10 +2310,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.8",
+ "smallvec",
+ "zeroize",
+]
 
 [[package]]
 name = "num-conv"
@@ -1760,12 +2347,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1785,6 +2392,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1813,6 +2426,16 @@ name = "owo-colors"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
 
 [[package]]
 name = "page_size"
@@ -1848,16 +2471,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -1904,6 +2568,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2619,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -1964,6 +2660,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,7 +2713,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2002,14 +2729,14 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2046,13 +2773,34 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2116,7 +2864,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2205,13 +2953,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2237,6 +3005,41 @@ checksum = "03451d4dc523c0a96d9e412c574670b3f5f184c3988b77a435876be25477bbd3"
 dependencies = [
  "log",
  "rusqlite",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -2367,6 +3170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +3201,39 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2423,6 +3268,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "self_update"
@@ -2542,6 +3393,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +3488,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -2762,11 +3629,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2826,6 +3713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -2903,6 +3791,15 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3015,10 +3912,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -3043,6 +3974,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3474,6 +4415,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3552,6 +4505,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3570,6 +4537,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -3594,7 +4562,7 @@ checksum = "32a55ebb27e67d9a9d116dd3a19637ee8cc0570c8ef816fb504c453f15448c99"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 name = "lade"
 version = "0.18.0"
 edition = "2024"
+default-run = "lade"
 description = "Temporary access to secrets, files, and private networks for one command, then gone. Same wrap for humans and agents. See which access was used."
 license = "MPL-2.0"
 repository = "https://github.com/zifeo/lade"
@@ -53,6 +54,9 @@ uuid = { version = "1.26.0", features = ["v7"] }
 tar = "0.4.46"
 flate2 = "1.1.10"
 tempfile = "3.27.0"
+age = { version = "0.12.1", default-features = false, features = ["ssh"] }
+age-plugin = "0.7.0"
+age-core = "0.12.0"
 
 [features]
 default = ["docker-tests"]
@@ -69,6 +73,20 @@ temp-env = "0.3"
 serde_json = "1.0.151"
 criterion = { version = "0.8", features = ["html_reports"] }
 rusqlite = { version = "0.40.2", features = ["bundled"] }
+
+[[bin]]
+name = "lade"
+path = "src/main.rs"
+
+# C2SP-specific: age/rage look up `age-plugin-<name>` on PATH.
+# Same program as `lade`, not a second crate. Cargo compiles it twice.
+# `lade upgrade` still copies the new `lade` onto this name: self_update
+# extracts one `bin_name` (`extract_file`). See src/upgrade/mod.rs.
+[[bin]]
+name = "age-plugin-lade"
+path = "src/main.rs"
+test = false
+bench = false
 
 [[bench]]
 name = "redact"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN set -eu; \
   curl -fsSL "${base}/${asset}" -o /tmp/lade.tar.gz; \
   curl -fsSL "${base}/${asset}.sha256" -o /tmp/lade.sha256; \
   echo "$(cut -d' ' -f1 /tmp/lade.sha256)  /tmp/lade.tar.gz" | sha256sum -c -; \
-  tar -xzf /tmp/lade.tar.gz -C /usr/local/bin lade; \
-  chmod +x /usr/local/bin/lade
+  tar -xzf /tmp/lade.tar.gz -C /usr/local/bin; \
+  chmod +x /usr/local/bin/lade; \
+  if [ -f /usr/local/bin/age-plugin-lade ]; then chmod +x /usr/local/bin/age-plugin-lade; fi
 
 FROM alpine:3
 RUN apk add --no-cache ca-certificates
-COPY --from=fetch /usr/local/bin/lade /usr/local/bin/lade
+COPY --from=fetch /usr/local/bin/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/lade"]

--- a/README.md
+++ b/README.md
@@ -464,6 +464,23 @@ Supported secret providers:
 | Inline value  | `"visible-in-lade-yml"`                              | Use `!` to force a raw value and `!!` to keep a leading `!`. |
 
 Use `lade eval <uri>` to resolve one URI when debugging a provider.
+Eval writes an `access` diary row (the URI, not the value). No
+`lade.yml` `log` flag.
+
+The release, installer, and `cargo install` put `age-plugin-lade` on
+the PATH next to `lade`. Both names are real binaries from the same
+crate. age and rage load the plugin when they see an `age1lade1…`
+recipient or an `AGE-PLUGIN-LADE-1…` identity. The payload is a Lade
+URI. The plugin hydrates it the same way eval does, then lets the age
+crate wrap or unwrap with the returned key (X25519, SSH, tagged, and
+post-quantum `age1tagpq1` recipients). `age-plugin-lade` plus a URI
+prints the identity file.
+
+```bash
+age-plugin-lade 'file://./age.json?query=.key' > identity.txt
+age -r "$(grep Recipient: identity.txt | awk '{print $3}')" -o secret.age secret.txt
+age -d -i identity.txt -o secret.txt secret.age
+```
 
 `file://` details:
 

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
       uses: actions/cache@v6
       with:
         path: ${{ inputs.out-dir }}
-        key: lade-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+        key: lade-bins-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: Install lade
       shell: bash
@@ -40,8 +40,8 @@ runs:
           VERSION_ENV="${LADE_VERSION#v}"
         fi
         if [ ! -x "$OUT_DIR/lade" ]; then
-          curl -fsSL https://raw.githubusercontent.com/zifeo/lade/main/installer.sh \
-            | CI=1 OUT_DIR="$OUT_DIR" VERSION="$VERSION_ENV" bash
+          CI=1 OUT_DIR="$OUT_DIR" VERSION="$VERSION_ENV" \
+            bash "$GITHUB_ACTION_PATH/installer.sh"
         fi
         echo "$OUT_DIR" >> "$GITHUB_PATH"
         "$OUT_DIR/lade" --version

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,14 @@ URI parse, CLI version tables, and tunnel command builders live in
 `lade-sdk`. The CLI owns process lifecycle (spawn, ready wait,
 restart, kill).
 
+`age-plugin-lade` is a second Cargo binary from the same `src/main.rs`.
+`argv0` or `--age-plugin=` selects the
+[C2SP age-plugin](https://c2sp.org/age-plugin) state machines. The
+payload is a Lade URI. Hydrate is `eval` (`hydrate_one`, no
+`lade.yml`). The age crate then wraps or unwraps with whatever that
+URI returned (X25519, SSH, tagged, post-quantum `age1tagpq1`). No
+network providers. No disclaimer.
+
 For shell hooks, `lade set` must finish both secret hydration and network
 acquisition before it can print the shell exports. When a matching rule contains
 network providers, the visible pre-command latency is therefore the slower of
@@ -306,8 +314,10 @@ An MCP server is a deliberate non-goal. Lade is an interceptor, not a data sourc
 
 ## 8. Observability
 
-Recording is opt-in. Last explicit `log` on **matching** rules wins.
-No-match `seen` uses last explicit `log` on the loaded walk. Secret
-values are never stored. Vault addresses and public keys are.
+Recording is opt-in on wrap paths. Last explicit `log` on **matching**
+rules wins. No-match `seen` uses last explicit `log` on the loaded
+walk. `lade eval` and `age-plugin-lade` are an access: they always
+write an `access` row. No `lade.yml` `log` flag. Secret values are
+never stored. Vault addresses and public keys are.
 
 Commands, schema, scrub, and share live in [observability.md](observability.md).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -41,7 +41,8 @@ A write failure never changes the command's exit.
 | Pretool handler, match | no (the wrap writes) |
 | MCP `tools/call` (`lade hook`) | `seen` |
 | `lade mcp` (server start) | same as inject |
-| unset, eval, status, bench, log, usage, on, off | no |
+| `lade eval`, `age-plugin-lade` | `access`. Always on. No `lade.yml` `log` flag. |
+| unset, status, bench, log, usage, on, off | no |
 
 Starting an MCP server is not a hook. A row exists only if the
 process is `lade mcp -- …` (or a URL). Each later `tools/call` is a

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -40,7 +40,8 @@ The child never sees the id or `LADE_T`. Direct inject ignores a leftover
 | Approve | then inject | same as inject |
 | MCP spawn | `lade mcp` | `mcp` |
 | MCP verb | `lade hook` (no T) | `mcp` |
-| Eval URI | `lade eval <uri>` | (none) |
+| Eval URI | `lade eval <uri>` | `organic` or `unknown` |
+| age plugin | `age-plugin-lade` | `organic` or `unknown` |
 
 ## Flow
 

--- a/installer.sh
+++ b/installer.sh
@@ -162,8 +162,11 @@ else
   printf "Warning: no checksum published for %s, skipping verification\n" "$ASSET.$EXT" >&2
 fi
 
-tar -C "$TMP_DIR" -xzf "$TMP_DIR/$ASSET.$EXT" "$EXE"
+tar -C "$TMP_DIR" -xzf "$TMP_DIR/$ASSET.$EXT"
 chmod +x "$TMP_DIR/$EXE"
+if [ -f "$TMP_DIR/age-plugin-lade" ]; then
+  chmod +x "$TMP_DIR/age-plugin-lade"
+fi
 
 # need_confirm returns 0 only for interactive human terminals.
 need_confirm() {
@@ -173,8 +176,17 @@ need_confirm() {
   return 0
 }
 
+install_extracted() {
+  dest_dir="$1"
+  run="${2-}"
+  $run mv "$TMP_DIR/$EXE" "$dest_dir"
+  if [ -f "$TMP_DIR/age-plugin-lade" ]; then
+    $run mv "$TMP_DIR/age-plugin-lade" "$dest_dir/age-plugin-lade"
+  fi
+}
+
 if [ "${OUT_DIR}" = "." ]; then
-  mv "$TMP_DIR/$EXE" .
+  install_extracted .
   printf "\n\n%s has been extracted to your current directory\n" "$EXE"
 else
   cat <<EOF
@@ -189,10 +201,10 @@ EOF
       printf "Press enter to continue (or cancel with Ctrl+C):"
       read -r _
     fi
-    mv "$TMP_DIR/$EXE" "$OUT_DIR"
+    install_extracted "$OUT_DIR"
   else
     printf "Sudo is required to run \"sudo mv %s %s\":\n" "$TMP_DIR/$EXE" "$OUT_DIR"
-    sudo mv "$TMP_DIR/$EXE" "$OUT_DIR"
+    install_extracted "$OUT_DIR" sudo
   fi
 fi
 

--- a/src/age_plugin/handler.rs
+++ b/src/age_plugin/handler.rs
@@ -1,0 +1,346 @@
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use age_core::format::{FileKey, Stanza};
+use age_plugin::identity::{self, IdentityPluginV1};
+use age_plugin::recipient::{self, RecipientPluginV1};
+use age_plugin::{Callbacks, PluginHandler};
+use tokio::runtime::Runtime;
+
+use super::parse::{as_identities, as_recipients};
+use crate::args::Command;
+use crate::audience;
+use crate::eval;
+
+pub const PLUGIN_NAME: &str = "lade";
+
+fn runtime() -> &'static Runtime {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("age-plugin-lade tokio runtime")
+    })
+}
+
+fn hydrate(uri: &str) -> Result<String, String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let stdin = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let stderr = std::io::IsTerminal::is_terminal(&std::io::stderr());
+    let d = audience::detect(
+        &Command::Eval {
+            uri: uri.to_string(),
+        },
+        false,
+        stdin,
+        stderr,
+    )
+    .expect("eval detect");
+    runtime()
+        .block_on(eval::resolve_uri(
+            uri.to_string(),
+            &cwd,
+            super::link::PLUGIN_BIN,
+            d.via,
+            d.audience,
+        ))
+        .map_err(|e| e.to_string())
+}
+
+fn lade_uri(name: &str, bytes: &[u8]) -> Result<String, String> {
+    if name != PLUGIN_NAME {
+        return Err(format!("unknown plugin {name}"));
+    }
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .map_err(|_| "payload is not UTF-8".into())
+}
+
+pub struct Handler;
+
+impl PluginHandler for Handler {
+    type RecipientV1 = LadeRecipient;
+    type IdentityV1 = LadeIdentity;
+
+    fn recipient_v1(self) -> io::Result<Self::RecipientV1> {
+        Ok(LadeRecipient {
+            entries: Vec::new(),
+        })
+    }
+
+    fn identity_v1(self) -> io::Result<Self::IdentityV1> {
+        Ok(LadeIdentity {
+            identities: Vec::new(),
+        })
+    }
+}
+
+enum EntryKind {
+    Recipient,
+    Identity,
+}
+
+struct Entry {
+    index: usize,
+    kind: EntryKind,
+    uri: String,
+}
+
+pub struct LadeRecipient {
+    entries: Vec<Entry>,
+}
+
+impl RecipientPluginV1 for LadeRecipient {
+    fn add_recipient(
+        &mut self,
+        index: usize,
+        plugin_name: &str,
+        bytes: &[u8],
+    ) -> Result<(), recipient::Error> {
+        let uri = lade_uri(plugin_name, bytes)
+            .map_err(|message| recipient::Error::Recipient { index, message })?;
+        self.entries.push(Entry {
+            index,
+            kind: EntryKind::Recipient,
+            uri,
+        });
+        Ok(())
+    }
+
+    fn add_identity(
+        &mut self,
+        index: usize,
+        plugin_name: &str,
+        bytes: &[u8],
+    ) -> Result<(), recipient::Error> {
+        let uri = lade_uri(plugin_name, bytes)
+            .map_err(|message| recipient::Error::Identity { index, message })?;
+        self.entries.push(Entry {
+            index,
+            kind: EntryKind::Identity,
+            uri,
+        });
+        Ok(())
+    }
+
+    fn labels(&mut self) -> HashSet<String> {
+        HashSet::new()
+    }
+
+    fn wrap_file_keys(
+        &mut self,
+        file_keys: Vec<FileKey>,
+        _callbacks: impl Callbacks<recipient::Error>,
+    ) -> io::Result<Result<Vec<Vec<Stanza>>, Vec<recipient::Error>>> {
+        let mut natives = Vec::new();
+        let mut errors = Vec::new();
+        for e in &self.entries {
+            match hydrate(&e.uri).and_then(|h| as_recipients(&h)) {
+                Ok(r) => natives.push(r),
+                Err(message) => errors.push(match e.kind {
+                    EntryKind::Recipient => recipient::Error::Recipient {
+                        index: e.index,
+                        message,
+                    },
+                    EntryKind::Identity => recipient::Error::Identity {
+                        index: e.index,
+                        message,
+                    },
+                }),
+            }
+        }
+        if !errors.is_empty() {
+            return Ok(Err(errors));
+        }
+        let mut out = Vec::with_capacity(file_keys.len());
+        for fk in &file_keys {
+            let mut stanzas = Vec::new();
+            for group in &natives {
+                for native in group {
+                    match native.wrap_file_key(fk) {
+                        Ok((mut s, _)) => stanzas.append(&mut s),
+                        Err(err) => {
+                            return Ok(Err(vec![recipient::Error::Internal {
+                                message: err.to_string(),
+                            }]));
+                        }
+                    }
+                }
+            }
+            out.push(stanzas);
+        }
+        Ok(Ok(out))
+    }
+}
+
+pub struct LadeIdentity {
+    identities: Vec<(usize, String)>,
+}
+
+impl IdentityPluginV1 for LadeIdentity {
+    fn add_identity(
+        &mut self,
+        index: usize,
+        plugin_name: &str,
+        bytes: &[u8],
+    ) -> Result<(), identity::Error> {
+        let uri = lade_uri(plugin_name, bytes)
+            .map_err(|message| identity::Error::Identity { index, message })?;
+        self.identities.push((index, uri));
+        Ok(())
+    }
+
+    fn unwrap_file_keys(
+        &mut self,
+        files: Vec<Vec<Stanza>>,
+        _callbacks: impl Callbacks<identity::Error>,
+    ) -> io::Result<HashMap<usize, Result<FileKey, Vec<identity::Error>>>> {
+        let mut natives = Vec::new();
+        let mut errors = Vec::new();
+        for (index, uri) in &self.identities {
+            match hydrate(uri).and_then(|h| as_identities(&h)) {
+                Ok(id) => natives.push(id),
+                Err(message) => errors.push(identity::Error::Identity {
+                    index: *index,
+                    message,
+                }),
+            }
+        }
+        if !errors.is_empty() {
+            let mut map = HashMap::new();
+            if !files.is_empty() {
+                map.insert(0, Err(errors));
+            }
+            return Ok(map);
+        }
+
+        let mut out = HashMap::new();
+        for (file_index, stanzas) in files.into_iter().enumerate() {
+            let mut file_errors = Vec::new();
+            let mut found = None;
+            for group in &natives {
+                for native in group {
+                    match native.unwrap_stanzas(&stanzas) {
+                        Some(Ok(fk)) => {
+                            found = Some(fk);
+                            break;
+                        }
+                        Some(Err(err)) => file_errors.push(identity::Error::Stanza {
+                            file_index,
+                            stanza_index: 0,
+                            message: err.to_string(),
+                        }),
+                        None => {}
+                    }
+                }
+                if found.is_some() {
+                    break;
+                }
+            }
+            if let Some(fk) = found {
+                out.insert(file_index, Ok(fk));
+            } else if !file_errors.is_empty() {
+                out.insert(file_index, Err(file_errors));
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use age_core::plugin::{Error, Result as PluginResult};
+    use age_core::secrecy::{ExposeSecret, SecretString};
+    use age_plugin::Callbacks;
+
+    struct Noop<E>(std::marker::PhantomData<E>);
+
+    impl<E> Noop<E> {
+        fn new() -> Self {
+            Self(std::marker::PhantomData)
+        }
+    }
+
+    impl<E> Callbacks<E> for Noop<E> {
+        fn message(&mut self, _: &str) -> PluginResult<()> {
+            Ok(Ok(()))
+        }
+
+        fn confirm(&mut self, _: &str, _: &str, _: Option<&str>) -> PluginResult<bool> {
+            Ok(Ok(true))
+        }
+
+        fn request_public(&mut self, _: &str) -> PluginResult<String> {
+            Ok(Err(Error::Fail))
+        }
+
+        fn request_secret(&mut self, _: &str) -> PluginResult<SecretString> {
+            Ok(Err(Error::Fail))
+        }
+
+        fn error(&mut self, _: E) -> PluginResult<()> {
+            Ok(Ok(()))
+        }
+    }
+
+    fn file_uri(dir: &std::path::Path, secret: &str) -> String {
+        let path = dir.join("key.json");
+        std::fs::write(&path, format!(r#"{{"key":"{secret}"}}"#)).unwrap();
+        format!("file://{}?query=.key", path.display())
+    }
+
+    #[test]
+    fn wrap_and_unwrap_via_file_uri() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = age::x25519::Identity::generate();
+        let secret = id.to_string().expose_secret().to_string();
+        let uri = file_uri(dir.path(), &secret);
+        let events = dir.path().join("events.db");
+        temp_env::with_var("LADE_EVENTS_PATH", Some(events.to_str().unwrap()), || {
+            let mut rec = LadeRecipient {
+                entries: Vec::new(),
+            };
+            rec.add_recipient(0, PLUGIN_NAME, uri.as_bytes())
+                .unwrap_or_else(|_| panic!("add recipient"));
+            let want = FileKey::new(Box::new([9u8; 16]));
+            let stanzas =
+                match rec.wrap_file_keys(vec![FileKey::new(Box::new([9u8; 16]))], Noop::new()) {
+                    Ok(Ok(s)) => s,
+                    Ok(Err(_)) => panic!("wrap failed"),
+                    Err(e) => panic!("wrap io: {e}"),
+                };
+            assert_eq!(stanzas[0][0].tag.to_ascii_lowercase(), "x25519");
+
+            let mut ident = LadeIdentity {
+                identities: Vec::new(),
+            };
+            ident
+                .add_identity(0, PLUGIN_NAME, uri.as_bytes())
+                .unwrap_or_else(|_| panic!("add identity"));
+            let out = ident
+                .unwrap_file_keys(stanzas, Noop::new())
+                .unwrap_or_else(|e| panic!("unwrap io: {e}"));
+            let got = match out.get(&0) {
+                Some(Ok(fk)) => fk,
+                _ => panic!("missing unwrapped file key"),
+            };
+            assert_eq!(got.expose_secret(), want.expose_secret());
+        });
+    }
+
+    #[test]
+    fn unknown_plugin_name_is_rejected() {
+        let mut rec = LadeRecipient {
+            entries: Vec::new(),
+        };
+        assert!(rec.add_recipient(0, "other", b"op://v/i/f").is_err());
+        let mut ident = LadeIdentity {
+            identities: Vec::new(),
+        };
+        assert!(ident.add_identity(0, "other", b"op://v/i/f").is_err());
+    }
+}

--- a/src/age_plugin/link.rs
+++ b/src/age_plugin/link.rs
@@ -4,20 +4,11 @@ use std::path::{Path, PathBuf};
 
 pub const PLUGIN_BIN: &str = "age-plugin-lade";
 
-pub fn plugin_bin_name() -> String {
-    if cfg!(windows) {
-        format!("{PLUGIN_BIN}.exe")
-    } else {
-        PLUGIN_BIN.to_string()
-    }
-}
-
 pub fn is_plugin_argv0(argv0: &std::ffi::OsStr) -> bool {
     let name = Path::new(argv0)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("");
-    let name = name.strip_suffix(".exe").unwrap_or(name);
     name.eq_ignore_ascii_case(PLUGIN_BIN)
 }
 
@@ -27,31 +18,17 @@ pub fn copy_beside(lade_path: &Path) -> io::Result<PathBuf> {
     let dir = lade_path
         .parent()
         .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "lade path has no parent directory"))?;
-    let dest = dir.join(plugin_bin_name());
-    let tmp = dir.join(format!("{}.new", plugin_bin_name()));
+    let dest = dir.join(PLUGIN_BIN);
+    let tmp = dir.join(format!("{PLUGIN_BIN}.new"));
     if tmp.exists() {
         fs::remove_file(&tmp)?;
     }
     fs::copy(lade_path, &tmp)?;
-    if let Err(err) = replace_dest(&tmp, &dest) {
+    if let Err(err) = fs::rename(&tmp, &dest) {
         let _ = fs::remove_file(&tmp);
         return Err(err);
     }
     Ok(dest)
-}
-
-fn replace_dest(tmp: &Path, dest: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        fs::rename(tmp, dest)
-    }
-    #[cfg(windows)]
-    {
-        if dest.exists() {
-            fs::remove_file(dest)?;
-        }
-        fs::rename(tmp, dest)
-    }
 }
 
 #[cfg(test)]
@@ -59,15 +36,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn plugin_argv0_matches_name_and_exe() {
+    fn plugin_argv0_matches_name() {
         assert!(is_plugin_argv0(std::ffi::OsStr::new("age-plugin-lade")));
-        assert!(is_plugin_argv0(std::ffi::OsStr::new("age-plugin-lade.exe")));
         assert!(is_plugin_argv0(std::ffi::OsStr::new(
             "/usr/local/bin/age-plugin-lade"
         )));
         assert!(is_plugin_argv0(std::ffi::OsStr::new("AGE-PLUGIN-LADE")));
         assert!(!is_plugin_argv0(std::ffi::OsStr::new("lade")));
         assert!(!is_plugin_argv0(std::ffi::OsStr::new("age-plugin-op")));
+        assert!(!is_plugin_argv0(std::ffi::OsStr::new(
+            "age-plugin-lade.exe"
+        )));
     }
 
     #[test]
@@ -75,25 +54,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let lade = dir.path().join("lade");
         fs::write(&lade, b"bin").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perm = fs::metadata(&lade).unwrap().permissions();
-            perm.set_mode(0o755);
-            fs::set_permissions(&lade, perm).unwrap();
-        }
         let dest = copy_beside(&lade).unwrap();
-        assert_eq!(dest.file_name().unwrap(), plugin_bin_name().as_str());
+        assert_eq!(dest.file_name().unwrap(), PLUGIN_BIN);
         assert_eq!(fs::read(&dest).unwrap(), b"bin");
-        #[cfg(unix)]
-        {
-            assert!(
-                !fs::symlink_metadata(&dest)
-                    .unwrap()
-                    .file_type()
-                    .is_symlink()
-            );
-        }
+        assert!(
+            !fs::symlink_metadata(&dest)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
         let dest2 = copy_beside(&lade).unwrap();
         assert_eq!(dest, dest2);
     }
@@ -101,7 +70,7 @@ mod tests {
     #[test]
     fn copy_beside_keeps_dest_when_source_is_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let dest = dir.path().join(plugin_bin_name());
+        let dest = dir.path().join(PLUGIN_BIN);
         fs::write(&dest, b"old").unwrap();
         let missing = dir.path().join("lade");
         assert!(copy_beside(&missing).is_err());

--- a/src/age_plugin/link.rs
+++ b/src/age_plugin/link.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::io::{self, Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+pub const PLUGIN_BIN: &str = "age-plugin-lade";
+
+pub fn plugin_bin_name() -> String {
+    if cfg!(windows) {
+        format!("{PLUGIN_BIN}.exe")
+    } else {
+        PLUGIN_BIN.to_string()
+    }
+}
+
+pub fn is_plugin_argv0(argv0: &std::ffi::OsStr) -> bool {
+    let name = Path::new(argv0)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let name = name.strip_suffix(".exe").unwrap_or(name);
+    name.eq_ignore_ascii_case(PLUGIN_BIN)
+}
+
+/// `lade upgrade` only. Install and `cargo install` already ship both bins.
+/// Copy into a sibling first so a failed copy leaves the existing plugin.
+pub fn copy_beside(lade_path: &Path) -> io::Result<PathBuf> {
+    let dir = lade_path
+        .parent()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "lade path has no parent directory"))?;
+    let dest = dir.join(plugin_bin_name());
+    let tmp = dir.join(format!("{}.new", plugin_bin_name()));
+    if tmp.exists() {
+        fs::remove_file(&tmp)?;
+    }
+    fs::copy(lade_path, &tmp)?;
+    if let Err(err) = replace_dest(&tmp, &dest) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+    Ok(dest)
+}
+
+fn replace_dest(tmp: &Path, dest: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        fs::rename(tmp, dest)
+    }
+    #[cfg(windows)]
+    {
+        if dest.exists() {
+            fs::remove_file(dest)?;
+        }
+        fs::rename(tmp, dest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_argv0_matches_name_and_exe() {
+        assert!(is_plugin_argv0(std::ffi::OsStr::new("age-plugin-lade")));
+        assert!(is_plugin_argv0(std::ffi::OsStr::new("age-plugin-lade.exe")));
+        assert!(is_plugin_argv0(std::ffi::OsStr::new(
+            "/usr/local/bin/age-plugin-lade"
+        )));
+        assert!(is_plugin_argv0(std::ffi::OsStr::new("AGE-PLUGIN-LADE")));
+        assert!(!is_plugin_argv0(std::ffi::OsStr::new("lade")));
+        assert!(!is_plugin_argv0(std::ffi::OsStr::new("age-plugin-op")));
+    }
+
+    #[test]
+    fn copy_beside_writes_a_second_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let lade = dir.path().join("lade");
+        fs::write(&lade, b"bin").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perm = fs::metadata(&lade).unwrap().permissions();
+            perm.set_mode(0o755);
+            fs::set_permissions(&lade, perm).unwrap();
+        }
+        let dest = copy_beside(&lade).unwrap();
+        assert_eq!(dest.file_name().unwrap(), plugin_bin_name().as_str());
+        assert_eq!(fs::read(&dest).unwrap(), b"bin");
+        #[cfg(unix)]
+        {
+            assert!(
+                !fs::symlink_metadata(&dest)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink()
+            );
+        }
+        let dest2 = copy_beside(&lade).unwrap();
+        assert_eq!(dest, dest2);
+    }
+
+    #[test]
+    fn copy_beside_keeps_dest_when_source_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join(plugin_bin_name());
+        fs::write(&dest, b"old").unwrap();
+        let missing = dir.path().join("lade");
+        assert!(copy_beside(&missing).is_err());
+        assert_eq!(fs::read(&dest).unwrap(), b"old");
+    }
+}

--- a/src/age_plugin/mod.rs
+++ b/src/age_plugin/mod.rs
@@ -1,0 +1,97 @@
+use std::ffi::OsString;
+
+use age_plugin::run_state_machine;
+use anyhow::Result;
+
+mod handler;
+mod link;
+mod parse;
+
+pub use handler::PLUGIN_NAME;
+pub(crate) use link::copy_beside;
+use link::is_plugin_argv0;
+
+pub enum Invoke {
+    StateMachine(String),
+    Encode(String),
+}
+
+pub fn invoke_from_argv(argv: &[OsString]) -> Option<Invoke> {
+    if argv.is_empty() {
+        return None;
+    }
+    let named = is_plugin_argv0(&argv[0]);
+    let mut sm = None;
+    let mut positionals = Vec::new();
+    let mut i = 1;
+    while i < argv.len() {
+        let a = argv[i].to_str().unwrap_or("");
+        if let Some(rest) = a.strip_prefix("--age-plugin=") {
+            sm = Some(rest.to_owned());
+        } else if a == "--age-plugin" {
+            sm = argv.get(i + 1).and_then(|s| s.to_str()).map(str::to_owned);
+            i += 1;
+        } else if !a.starts_with('-') {
+            positionals.push(a.to_owned());
+        }
+        i += 1;
+    }
+    if let Some(sm) = sm {
+        return Some(Invoke::StateMachine(sm));
+    }
+    if named {
+        return positionals.first().cloned().map(Invoke::Encode);
+    }
+    None
+}
+
+pub fn run(invoke: Invoke) -> Result<()> {
+    match invoke {
+        Invoke::StateMachine(sm) => {
+            run_state_machine(&sm, handler::Handler).map_err(|e| anyhow::anyhow!(e))?;
+        }
+        Invoke::Encode(uri) => {
+            age_plugin::print_new_identity(PLUGIN_NAME, uri.as_bytes(), uri.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn intercepts_equals_form() {
+        let v = invoke_from_argv(&os(&["lade", "--age-plugin=identity-v1"])).unwrap();
+        assert!(matches!(v, Invoke::StateMachine(s) if s == "identity-v1"));
+    }
+
+    #[test]
+    fn intercepts_separate_form() {
+        let v = invoke_from_argv(&os(&["lade", "--age-plugin", "recipient-v1"])).unwrap();
+        assert!(matches!(v, Invoke::StateMachine(s) if s == "recipient-v1"));
+    }
+
+    #[test]
+    fn named_binary_without_uri_is_none() {
+        assert!(invoke_from_argv(&os(&["age-plugin-lade"])).is_none());
+    }
+
+    #[test]
+    fn named_binary_encodes_uri() {
+        let v =
+            invoke_from_argv(&os(&["age-plugin-lade", "file:///tmp/k.json?query=.key"])).unwrap();
+        assert!(matches!(v, Invoke::Encode(u) if u == "file:///tmp/k.json?query=.key"));
+    }
+
+    #[test]
+    fn normal_lade_argv_is_ignored() {
+        assert!(invoke_from_argv(&os(&["lade", "eval", "op://v/i/f"])).is_none());
+        assert!(invoke_from_argv(&os(&["lade", "install"])).is_none());
+    }
+}

--- a/src/age_plugin/parse.rs
+++ b/src/age_plugin/parse.rs
@@ -1,0 +1,170 @@
+use std::io::Cursor;
+
+use age::{Identity, IdentityFile, Recipient};
+
+fn first_data_line(hydrated: &str) -> &str {
+    hydrated
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .unwrap_or("")
+}
+
+// Go age 1.3 native keys (`age1pq1`, `AGE-SECRET-KEY-PQ-1`). rage 0.12 only
+// has tagpq encrypt. str4d/rage#632 (draft, 0.13) adds pq recipient + identity.
+fn reject_unsupported(hydrated: &str) -> Result<(), String> {
+    let line = first_data_line(hydrated);
+    if line.to_ascii_uppercase().starts_with("AGE-PLUGIN-") {
+        return Err("hydrated value is another AGE-PLUGIN identity".into());
+    }
+    let lower = line.to_ascii_lowercase();
+    if lower.starts_with("age-secret-key-pq-") || lower.starts_with("age1pq1") {
+        return Err(
+            "the age crate cannot use Go age 1.3 post-quantum keys (AGE-SECRET-KEY-PQ / age1pq1)"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+fn parse_recipient_line(line: &str) -> Result<Box<dyn Recipient + Send>, String> {
+    if let Ok(r) = line.parse::<age::x25519::Recipient>() {
+        return Ok(Box::new(r));
+    }
+    if let Ok(r) = line.parse::<age::tag::Recipient>() {
+        return Ok(Box::new(r));
+    }
+    if let Ok(r) = line.parse::<age::tagpq::Recipient>() {
+        return Ok(Box::new(r));
+    }
+    if let Ok(r) = line.parse::<age::ssh::Recipient>() {
+        return Ok(Box::new(r));
+    }
+    Err("age could not use the hydrated value as a recipient".into())
+}
+
+pub(super) fn as_recipients(hydrated: &str) -> Result<Vec<Box<dyn Recipient + Send>>, String> {
+    reject_unsupported(hydrated)?;
+    if let Ok(file) = IdentityFile::from_buffer(Cursor::new(hydrated.as_bytes()))
+        && let Ok(rs) = file.to_recipients()
+        && !rs.is_empty()
+    {
+        return Ok(rs);
+    }
+    if let Ok(r) = parse_recipient_line(first_data_line(hydrated)) {
+        return Ok(vec![r]);
+    }
+    if let Ok(id) = age::ssh::Identity::from_buffer(Cursor::new(hydrated.as_bytes()), None) {
+        let r = age::ssh::Recipient::try_from(id)
+            .map_err(|e| format!("age rejected the hydrated value: {e:?}"))?;
+        return Ok(vec![Box::new(r)]);
+    }
+    Err("age could not use the hydrated value as a recipient".into())
+}
+
+pub(super) fn as_identities(
+    hydrated: &str,
+) -> Result<Vec<Box<dyn Identity + Send + Sync>>, String> {
+    reject_unsupported(hydrated)?;
+    if let Ok(file) = IdentityFile::from_buffer(Cursor::new(hydrated.as_bytes())) {
+        return file.into_identities().map_err(|e| e.to_string());
+    }
+    if let Ok(id) = age::ssh::Identity::from_buffer(Cursor::new(hydrated.as_bytes()), None) {
+        return Ok(vec![Box::new(id)]);
+    }
+    Err("age could not use the hydrated value as an identity".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use age_core::secrecy::ExposeSecret;
+
+    use super::*;
+
+    const TAG_RECIPIENT: &str =
+        "age1tag1qt8lw0ual6avlwmwatk888yqnmdamm7xfd0wak53ut6elz5c4swx2yqdj4e";
+
+    fn identity_secret(id: &age::x25519::Identity) -> String {
+        id.to_string().expose_secret().to_string()
+    }
+
+    fn wrap_ok(hydrated: &str) -> String {
+        let recipients = as_recipients(hydrated).unwrap();
+        let file_key = age_core::format::FileKey::new(Box::new([7u8; 16]));
+        let (stanzas, _) = recipients[0].wrap_file_key(&file_key).unwrap();
+        stanzas[0].tag.to_ascii_lowercase()
+    }
+
+    #[test]
+    fn identity_file_wraps_and_unwraps() {
+        let id = age::x25519::Identity::generate();
+        let secret = identity_secret(&id);
+        let file_key = age_core::format::FileKey::new(Box::new([7u8; 16]));
+        let recipients = as_recipients(&secret).unwrap();
+        let (stanzas, _) = recipients[0].wrap_file_key(&file_key).unwrap();
+        assert_eq!(stanzas[0].tag.to_ascii_lowercase(), "x25519");
+        let identities = as_identities(&secret).unwrap();
+        let got = identities[0].unwrap_stanzas(&stanzas).unwrap().unwrap();
+        assert_eq!(got.expose_secret(), file_key.expose_secret());
+    }
+
+    #[test]
+    fn public_recipient_wraps() {
+        let id = age::x25519::Identity::generate();
+        let public = id.to_public().to_string();
+        let file_key = age_core::format::FileKey::new(Box::new([3u8; 16]));
+        let recipients = as_recipients(&public).unwrap();
+        let (stanzas, _) = recipients[0].wrap_file_key(&file_key).unwrap();
+        let identities = as_identities(&identity_secret(&id)).unwrap();
+        let got = identities[0].unwrap_stanzas(&stanzas).unwrap().unwrap();
+        assert_eq!(got.expose_secret(), file_key.expose_secret());
+    }
+
+    #[test]
+    fn tag_recipient_wraps() {
+        assert_eq!(wrap_ok(TAG_RECIPIENT), "p256tag");
+    }
+
+    #[test]
+    fn tagpq_recipient_wraps() {
+        let recipient: age::tagpq::Recipient = AGE_TAGPQ_TEST.parse().unwrap();
+        assert_eq!(wrap_ok(&recipient.to_string()), "mlkem768p256tag");
+    }
+
+    #[test]
+    fn go_pq_identity_is_rejected() {
+        match as_identities(
+            "AGE-SECRET-KEY-PQ-1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+        ) {
+            Err(err) => assert!(err.contains("post-quantum")),
+            Ok(_) => panic!("Go age PQ identity should fail"),
+        }
+        match as_recipients("age1pq1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") {
+            Err(err) => assert!(err.contains("post-quantum")),
+            Ok(_) => panic!("Go age PQ recipient should fail"),
+        }
+    }
+
+    #[test]
+    fn plugin_identity_is_rejected() {
+        match as_identities("AGE-PLUGIN-OTHER-1qypqxpq9qypqxpq9qypqxpq9qypqxpq9") {
+            Err(err) => assert!(err.contains("AGE-PLUGIN")),
+            Ok(_) => panic!("plugin identity should fail"),
+        }
+        match as_recipients("AGE-PLUGIN-OTHER-1qypqxpq9qypqxpq9qypqxpq9qypqxpq9") {
+            Err(err) => assert!(err.contains("AGE-PLUGIN")),
+            Ok(_) => panic!("plugin recipient should fail"),
+        }
+    }
+
+    #[test]
+    fn comment_header_is_ignored() {
+        let id = age::x25519::Identity::generate();
+        let blob = format!("# created: now\n{}\n", identity_secret(&id));
+        assert!(as_identities(&blob).is_ok());
+        assert!(as_recipients(&blob).is_ok());
+    }
+
+    // rage 0.12 test vector (`age::tagpq` tests).
+    const AGE_TAGPQ_TEST: &str = "age1tagpq1m3e4wvp6hzcrn9exhy0ae3xfx2sjymp594k3tg7j4dpmj922we65vtnmrt2pyallax8669zqkr2pmfchptr4n38kug2xmcmp3adk2lnjqu00x5kxz5pvhmrltvfh9wuq973pcx35cnq8syn9qd3tzpehgztl4xpzr3tpd67g8af9trnjpc05gh7wu536aq4qt2y8zhsm4tvrfpsfl36qs5fpzysnk3sp9w77qzeg49357xex40v4s2lvt620swyys7u8yxdcnu4rkkwxdmt55gsuc3h5c5swahnegjgqwc60hn085ec3sjztwm45l44y3j2at9t6v9zra4ek3kek6waecqm98yaxl37w0d2zra626nz63jdm5sg59w7lyptw83zm6fntd8d0x03a9z6h9prfgpygzar6zrxjcrt4cdctk2mhf95s4a6v4zklfd49xhpsaeujm57thx2x3e3hwzc86ftfhmq5mkxxz3d6r8ws24xj4qfn73eyezg2wy094e3why592pghz27ruq3vkyegrv80eftnw9wqzwgvnwyseaus0yt84fylzrpzp6x2fguxuqjmgudr8xd33qm30evdpxd3jvjg8qh4q60kyq80jgff369k7nrepdc38grd2dava520excqp0ey0x39khx8ry03yffcatgv84fsx5j49djpapedsy693zute5xv5g2ewzrlj5se7akvkc4g4vmzhputpq8eyj9wz5dz6qtn7g3cfpd95nahw4ytspan0feyye04dcylv24ege7zkaj004gjwcxqxfqu2quawa83sx452jqjn8t48czp0xspwgnmvjyhttzzy6nhq8xzkdwnvsfefkwva6asrqc93zjn4rly5gnlv93xy3uzmr39szvjnf63426qzyeyvguc4vdcquwgsxgq236afcpqz866ny4tn7ckc0umefj242rt5vtvwqzzrvfev2mpvqcufp9pqvefyv4ftyuhgausfzuaadsczeykmft5wv3frzgrcp9ztr93h478ke4t86spp2uhyjkj73mp9g92ddk2fpv7v3njzsqgwhq3789sqrgkskehn0zjscckhwftyq4vet7vrlx2hs5kd9cwnq6t0djffhh3zquh4j3p0yaj9z2rc9wykg0usqw7983rrgur9jg8rnnqypwcz2lyclnnc705fc5g3an93ps60q6mxqp85u0ewtxdjlqcks84yduft0a0g6e7naew3v9u2d08knarvajn8q3gq9pgxde3s7nx94lus48wwvw2xjm7k82tvylec2393jdsuvch2xpe77w8hpv9nvsxfsrs270njpmfvpmgyk2cffl9tjp3qqcc4dfkf5rme2dg0x7ew8g39www5smm705q5da4eqvnqwrkavtq6xje9ss38hnkglz4eddz8f5qruvqmq2ff9l22gwkv8h432rdkysy0grkul8e2fedvkyyapfxt760udcgu92m54wl9yavmj4ga3ph9r5n99cjrq6wj5v33x33fe5vkjvfwnnt40wuv2hyexc9f4ylyqv9ldqq9epd4yuv8vrsfx2qy2kqz08kqhnzspy6s0x8fa5c2xkg5y2q0rvz4vnk7rp0acg6eksc3t7cxnn8y7glkjsqja3p56uz6vvhcw55d3ysad0hvsqxpjnc7svenf2gc5xn5kyr0et2vvyruxlnpqcdpqh9pzplumy5yzjxftyzh9ujfw0jq7ee60zx2x23p0jzyh9dvmly8p9h9ysptlqu7kwnejd65dnr75a0np2fvke8xen38r57w6z3wz3mycjmmn267wwxndfh9jdps7uxtct2wwfgamkpa5ap8s96lhfjztpwcm6fguhphu38yunu2v4vz3syzrvgwtqpemkewzp766nyu6texxvjlaemnhyyqutkcy6a42vqfsz49rw5wr4gt70r4vdaasehqjg46fnyts4sthrxadfllha3avu49wsj2c4jx";
+}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -43,6 +43,13 @@ pub(crate) async fn run_standalone(
             Ok(None)
         }
         Command::Upgrade(opts) => upgrade::perform(opts).await.map(|()| None),
+        Command::Eval { uri } => {
+            let current_dir = std::env::current_dir()?;
+            let value =
+                crate::eval::resolve_uri(uri, &current_dir, "eval", ctx.via, ctx.audience).await?;
+            println!("{value}");
+            Ok(None)
+        }
         Command::Hook {
             action: Some(action),
             ..

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::Result;
+use lade_sdk::hydrate_one;
+use serde_json::{Value, json};
+
+use crate::audience::Via;
+use crate::config::Audience;
+use crate::event::{self, Emit, Kind};
+
+pub async fn resolve_uri(
+    uri: String,
+    cwd: &Path,
+    command: &str,
+    via: Via,
+    audience: Audience,
+) -> Result<String> {
+    let started = Instant::now();
+    let value = hydrate_one(uri.clone(), cwd, &HashMap::new()).await?;
+    emit_fetch(command, &uri, cwd, via, audience, started);
+    Ok(value)
+}
+
+fn emit_fetch(
+    command: &str,
+    uri: &str,
+    cwd: &Path,
+    via: Via,
+    audience: Audience,
+    started: Instant,
+) {
+    event::emit(Emit {
+        kind: Kind::Access,
+        via,
+        audience,
+        actor: event::actor(&None),
+        cwd: cwd.to_path_buf(),
+        command: command.to_string(),
+        argv: Some(json!([uri])),
+        hydrated: None,
+        matches: json!([{ "bindings": [{ "uri": uri }] }]),
+        hydrate_ms: Some(started.elapsed().as_secs_f64() * 1000.0),
+        agent: crate::agent_meta::merge(Value::Null),
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::{env, time::Duration};
 
 mod access;
+mod age_plugin;
 mod agent_meta;
 mod args;
 mod audience;
@@ -12,6 +13,7 @@ mod compat;
 mod config;
 mod context;
 mod dispatch;
+mod eval;
 mod event;
 mod exec;
 mod exit_codes;
@@ -41,16 +43,7 @@ use clap::Parser;
 use config::LadeFile;
 use context::InvocationContext;
 use dispatch::{run_config_verbs, run_standalone};
-use lade_sdk::hydrate_one;
-
 fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?
-        .block_on(run())
-}
-
-async fn run() -> Result<()> {
     #[cfg(target_family = "unix")]
     {
         // fix the pipe: https://github.com/rust-lang/rust/issues/46016
@@ -60,6 +53,18 @@ async fn run() -> Result<()> {
         }
     }
 
+    let argv: Vec<_> = std::env::args_os().collect();
+    if let Some(invoke) = age_plugin::invoke_from_argv(&argv) {
+        return age_plugin::run(invoke);
+    }
+
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> Result<()> {
     let (peeled_ticket_id, argv) = ticket::peel_pretool(std::env::args_os().collect());
     let args = Args::try_parse_from(&argv)?;
 
@@ -132,16 +137,6 @@ async fn run() -> Result<()> {
     };
 
     let current_dir = env::current_dir()?;
-
-    if let Command::Eval { uri } = command {
-        let value =
-            hydrate_one(uri.clone(), &current_dir, &std::collections::HashMap::new()).await?;
-        if ctx.is_interactive() {
-            compat::warn_outdated(&ctx, compat::known_schemes(std::iter::once(uri.as_str()))).await;
-        }
-        println!("{}", value);
-        return Ok(());
-    }
 
     let config = match LadeFile::build(current_dir.clone()) {
         Ok(c) => c,

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -142,6 +142,7 @@ pub async fn perform(opts: UpgradeCommand) -> Result<()> {
         update
             .repo_owner("zifeo")
             .repo_name("lade")
+            // One name. The tarball also has `age-plugin-lade` (Cargo.toml).
             .bin_name("lade")
             .show_download_progress(true)
             .current_version(cargo_crate_version!())
@@ -184,6 +185,14 @@ pub async fn perform(opts: UpgradeCommand) -> Result<()> {
     .await??;
     if updated {
         let _ = GlobalConfig::update(void_daily_stamps).await;
+        // self_update's default path is extract_file(bin_name). It does not
+        // install the second Cargo binary from the tarball. Copy the new lade
+        // onto age-plugin-lade so the C2SP name stays in sync.
+        if let std::result::Result::Ok(exe) = std::env::current_exe()
+            && let Err(err) = crate::age_plugin::copy_beside(&exe)
+        {
+            log::debug!("age-plugin-lade copy: {err}");
+        }
     }
     Ok(())
 }

--- a/tests/age_plugin.rs
+++ b/tests/age_plugin.rs
@@ -1,0 +1,31 @@
+use assert_cmd::Command;
+
+#[test]
+fn named_binary_prints_plugin_identity() {
+    Command::cargo_bin("age-plugin-lade")
+        .unwrap()
+        .arg("file:///tmp/key.json?query=.key")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("AGE-PLUGIN-LADE-1"))
+        .stdout(predicates::str::contains("age1lade1"));
+}
+
+#[test]
+fn lade_age_plugin_flag_unknown_machine_fails() {
+    Command::cargo_bin("lade")
+        .unwrap()
+        .arg("--age-plugin=no-such-v1")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn lade_without_plugin_flag_is_still_lade() {
+    Command::cargo_bin("lade")
+        .unwrap()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("lade"));
+}

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -1,0 +1,43 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn eval_prints_file_uri_and_writes_diary() {
+    let home = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let key = dir.path().join("secret.json");
+    std::fs::write(&key, r#"{"token":"eval-secret-value"}"#).unwrap();
+    let uri = format!("file://{}?query=.token", key.display());
+
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["eval", &uri])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("eval-secret-value"));
+
+    let rows = common::log_rows(home.path(), dir.path());
+    let items = rows.as_array().expect("log array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["kind"], "access");
+    assert_eq!(items[0]["command"], "eval");
+    let dump = serde_json::to_string(&items[0]).unwrap();
+    assert!(dump.contains(&uri), "{dump}");
+    assert!(
+        !dump.contains("eval-secret-value"),
+        "diary stored the secret: {dump}"
+    );
+}
+
+#[test]
+fn eval_unknown_uri_is_literal() {
+    let home = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    common::lade(home.path())
+        .current_dir(dir.path())
+        .args(["eval", "not-a-scheme"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("not-a-scheme\n"));
+}

--- a/tests/installer_test.sh
+++ b/tests/installer_test.sh
@@ -60,8 +60,9 @@ cat >"$BIN_DIR/lade" <<'EOF'
 #!/bin/sh
 echo "lade 0.0.0-test"
 EOF
-chmod +x "$BIN_DIR/lade"
-tar -C "$BIN_DIR" -czf "$ASSET_DIR/$ASSET.tar.gz" lade
+cp "$BIN_DIR/lade" "$BIN_DIR/age-plugin-lade"
+chmod +x "$BIN_DIR/lade" "$BIN_DIR/age-plugin-lade"
+tar -C "$BIN_DIR" -czf "$ASSET_DIR/$ASSET.tar.gz" lade age-plugin-lade
 sha256_of "$ASSET_DIR/$ASSET.tar.gz" >"$ASSET_DIR/$ASSET.tar.gz.sha256"
 
 # --- start HTTP server -----------------------------------------------------
@@ -92,6 +93,8 @@ for dl in curl wget; do
   OUT1="$WORK/out1-$dl"
   if run_installer "$OUT1" DOWNLOADER="$dl" >"$WORK/log1-$dl" 2>&1; then
     [ -x "$OUT1/lade" ] || fail "binary not installed in positive case ($dl)"
+    [ -x "$OUT1/age-plugin-lade" ] || fail "age-plugin-lade missing ($dl)"
+    [ ! -L "$OUT1/age-plugin-lade" ] || fail "age-plugin-lade should be a real binary, not a symlink ($dl)"
     grep -q "Checksum verified" "$WORK/log1-$dl" || fail "checksum was not verified ($dl)"
     "$OUT1/lade" | grep -q "0.0.0-test" || fail "installed binary does not run ($dl)"
     pass "positive install with checksum verification ($dl)"
@@ -117,6 +120,8 @@ rm -f "$ASSET_DIR/$ASSET.tar.gz.sha256"
 OUT3="$WORK/out3"
 if run_installer "$OUT3" >"$WORK/log3" 2>&1; then
   [ -x "$OUT3/lade" ] || fail "binary not installed when checksum missing"
+  [ -x "$OUT3/age-plugin-lade" ] || fail "age-plugin-lade missing when checksum missing"
+  [ ! -L "$OUT3/age-plugin-lade" ] || fail "age-plugin-lade should be a real binary, not a symlink"
   grep -qi "no checksum published" "$WORK/log3" || fail "missing checksum warning absent"
   pass "missing checksum tolerated with warning"
 else


### PR DESCRIPTION
## Summary
- Cargo builds `lade` and `age-plugin-lade` from the same `main`. The release tarball, installer, image, and `cargo install` ship both files.
- age and rage hydrate a Lade URI the same way `lade eval` does, then wrap or unwrap with the age crate (X25519, SSH, tagged, `age1tagpq1`).
- `lade upgrade` copies the new `lade` onto the plugin name because self_update extracts one binary. Copy goes through a sibling file first so a failed copy keeps the old plugin.

## Test plan
- [ ] `cargo test --workspace --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `bash tests/installer_test.sh`
- [ ] `age-plugin-lade 'file://./age.json?query=.key'` prints `AGE-PLUGIN-LADE-1` / `age1lade1`
- [ ] `lade eval file://…` writes an `access` diary row (URI only)