### PR TITLE
fix: skip wrap when a match has nothing to inject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,53 +57,16 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43"
-dependencies = [
- "aes",
- "aes-gcm",
- "age-core 0.11.0",
- "base64 0.21.7",
- "bcrypt-pbkdf",
- "bech32 0.9.1",
- "cbc",
- "chacha20poly1305",
- "cipher",
- "cookie-factory",
- "ctr",
- "curve25519-dalek",
- "hmac 0.12.1",
- "i18n-embed 0.15.4",
- "i18n-embed-fl 0.9.4",
- "lazy_static",
- "nom 7.1.3",
- "num-traits",
- "pin-project",
- "rand 0.8.8",
- "rsa",
- "rust-embed",
- "scrypt",
- "sha2 0.10.9",
- "subtle",
- "which",
- "wsl",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "age"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "aes",
  "aes-gcm",
- "age-core 0.12.0",
+ "age-core",
  "base64 0.22.1",
  "bcrypt-pbkdf",
- "bech32 0.11.1",
+ "bech32",
  "cbc",
  "chacha20poly1305",
  "cipher",
@@ -113,11 +76,11 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "hpke",
- "i18n-embed 0.16.0",
- "i18n-embed-fl 0.10.1",
+ "i18n-embed",
+ "i18n-embed-fl",
  "lazy_static",
  "ml-kem",
- "nom 8.0.0",
+ "nom",
  "num-traits",
  "p256",
  "pin-project",
@@ -128,26 +91,10 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "age-core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
-dependencies = [
- "base64 0.21.7",
- "chacha20poly1305",
- "cookie-factory",
- "hkdf",
- "io_tee",
- "nom 7.1.3",
- "rand 0.8.8",
- "secrecy",
- "sha2 0.10.9",
- "tempfile",
 ]
 
 [[package]]
@@ -157,13 +104,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
  "base64 0.22.1",
- "bech32 0.11.1",
+ "bech32",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
  "hpke",
  "io_tee",
- "nom 8.0.0",
+ "nom",
  "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
@@ -176,9 +123,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e639a0bf4973247c88bc8ff08517f0ee438d19ba3d40f6f340353c6ba9fc2aa"
 dependencies = [
- "age-core 0.12.0",
+ "age-core",
  "base64 0.22.1",
- "bech32 0.11.1",
+ "bech32",
  "chrono",
 ]
 
@@ -281,15 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,174 +253,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.5.0",
- "futures-lite 2.6.1",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.6.1",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.2",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-object-pool"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
 dependencies = [
- "async-std",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
  "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.2",
- "futures-lite 2.6.1",
- "rustix 1.1.4",
+ "event-listener",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.1",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -527,7 +316,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "hex",
  "http 1.5.0",
  "sha1",
@@ -590,7 +379,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytes-utils",
- "fastrand 2.5.0",
+ "fastrand",
  "http 1.5.0",
  "http-body 1.1.0",
  "percent-encoding",
@@ -618,7 +407,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.5.0",
  "regex-lite",
@@ -644,7 +433,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.5.0",
  "regex-lite",
@@ -670,7 +459,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.5.0",
  "regex-lite",
@@ -697,7 +486,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand 2.5.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.5.0",
  "regex-lite",
@@ -769,7 +558,7 @@ dependencies = [
  "aws-smithy-types",
  "h2",
  "http 1.5.0",
- "hyper 1.11.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -829,7 +618,7 @@ dependencies = [
  "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -936,50 +725,54 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.21.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b552ad43a45a746461ec3d3a51dfb6466b4759209414b439c165eb6a6b7729e"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
 dependencies = [
+ "async-lock",
  "async-trait",
- "base64 0.22.1",
+ "azure_core_macros",
  "bytes",
- "dyn-clone",
  "futures",
- "getrandom 0.2.17",
- "http-types",
- "once_cell",
- "paste",
  "pin-project",
- "rand 0.8.8",
- "reqwest 0.12.28",
  "rustc_version",
  "serde",
  "serde_json",
- "time",
+ "tokio",
  "tracing",
- "url",
- "uuid",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "tracing",
 ]
 
 [[package]]
 name = "azure_identity"
-version = "0.21.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ddd80344317c40c04b603807b63a5cefa532f1b43522e72f480a988141f744"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
- "async-process",
  "async-trait",
  "azure_core",
  "futures",
- "oauth2",
  "pin-project",
  "serde",
+ "serde_json",
  "time",
+ "tokio",
  "tracing",
- "tz-rs",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -987,18 +780,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1029,17 +810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "basic-cookies"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
-dependencies = [
- "lalrpop",
- "lalrpop-util",
- "regex",
-]
-
-[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,24 +831,9 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
 
 [[package]]
 name = "bit-set"
@@ -1086,14 +841,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1141,19 +890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
-]
-
-[[package]]
 name = "blowfish"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +927,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1410,15 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,12 +1191,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "cookie"
@@ -1788,16 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,19 +1519,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -1912,15 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,12 +1685,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
@@ -2011,7 +1699,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.2",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2033,18 +1721,9 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -2095,12 +1774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,37 +1795,11 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
-dependencies = [
- "fluent-bundle 0.15.3",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
 dependencies = [
- "fluent-bundle 0.16.0",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-bundle"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
-dependencies = [
- "fluent-langneg",
- "fluent-syntax 0.11.1",
- "intl-memoizer",
- "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
- "smallvec",
+ "fluent-bundle",
  "unic-langid",
 ]
 
@@ -2163,11 +1810,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
- "fluent-syntax 0.12.0",
+ "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 2.1.3",
- "self_cell 1.3.0",
+ "rustc-hash",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -2179,15 +1826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
 dependencies = [
  "unic-langid",
-]
-
-[[package]]
-name = "fluent-syntax"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2276,34 +1914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.5.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +1935,12 @@ name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2356,7 +1972,7 @@ dependencies = [
  "chrono",
  "http 1.5.0",
  "http-body-util",
- "hyper 1.11.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "rustls",
@@ -2383,17 +1999,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -2401,7 +2006,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2427,18 +2032,6 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2516,16 +2109,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.5.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.5.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2558,15 +2169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2645,26 +2247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2678,29 +2260,35 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
- "async-std",
  "async-trait",
- "base64 0.21.7",
- "basic-cookies",
+ "base64 0.22.1",
+ "bytes",
  "crossbeam-utils",
  "form_urlencoded",
+ "futures-timer",
  "futures-util",
- "hyper 0.14.32",
- "lazy_static",
- "levenshtein",
- "log",
+ "headers",
+ "http 1.5.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "path-tree",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
  "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror 2.0.20",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2724,29 +2312,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
@@ -2759,6 +2324,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2773,14 +2339,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.5.0",
- "hyper 1.11.1",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2795,12 +2360,12 @@ dependencies = [
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.11.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2822,34 +2387,14 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
-dependencies = [
- "arc-swap",
- "fluent 0.16.1",
- "fluent-langneg",
- "fluent-syntax 0.11.1",
- "i18n-embed-impl",
- "intl-memoizer",
- "log",
- "parking_lot",
- "rust-embed",
- "thiserror 1.0.69",
- "unic-langid",
- "walkdir",
-]
-
-[[package]]
-name = "i18n-embed"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
 dependencies = [
  "arc-swap",
- "fluent 0.17.0",
+ "fluent",
  "fluent-langneg",
- "fluent-syntax 0.12.0",
+ "fluent-syntax",
  "i18n-embed-impl",
  "intl-memoizer",
  "log",
@@ -2858,25 +2403,6 @@ dependencies = [
  "thiserror 1.0.69",
  "unic-langid",
  "walkdir",
-]
-
-[[package]]
-name = "i18n-embed-fl"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
-dependencies = [
- "find-crate",
- "fluent 0.16.1",
- "fluent-syntax 0.11.1",
- "i18n-config",
- "i18n-embed 0.15.4",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
- "unic-langid",
 ]
 
 [[package]]
@@ -2886,10 +2412,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602e6bd30c3db2749e13e38b363a3d98d9d41de1d8de7a79c31bb69e45b47cda"
 dependencies = [
  "find-crate",
- "fluent 0.17.0",
- "fluent-syntax 0.12.0",
+ "fluent",
+ "fluent-syntax",
  "i18n-config",
- "i18n-embed 0.16.0",
+ "i18n-embed",
  "proc-macro-error3",
  "proc-macro2",
  "quote",
@@ -3065,12 +2591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,15 +2598,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3125,15 +2636,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3285,20 +2787,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lade"
 version = "0.18.1-beta.1"
 dependencies = [
- "age 0.12.1",
- "age-core 0.12.0",
+ "age",
+ "age-core",
  "age-plugin",
  "aho-corasick",
  "anyhow",
@@ -3322,10 +2815,10 @@ dependencies = [
  "owo-colors",
  "predicates",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rusqlite",
  "rusqlite_migration",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "self_update",
  "semver",
  "serde",
@@ -3337,7 +2830,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tokio",
- "toml 0.8.23",
+ "toml 1.1.5+spec-1.1.0",
  "url",
  "uuid",
 ]
@@ -3347,7 +2840,7 @@ name = "lade-sdk"
 version = "0.18.1-beta.1"
 dependencies = [
  "access-json",
- "age 0.11.5",
+ "age",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -3363,9 +2856,9 @@ dependencies = [
  "log",
  "once_cell",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "rust-ini",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "semver",
  "serde",
  "serde_json",
@@ -3378,37 +2871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,12 +2878,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -3457,12 +2913,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3493,9 +2943,6 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -3526,12 +2973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,7 +2989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -3593,12 +3034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,16 +3043,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3684,34 +3109,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.17",
- "http 0.2.12",
- "rand 0.8.8",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -3822,10 +3219,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "path-tree"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -3842,31 +3242,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -3899,17 +3274,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand 2.5.0",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs1"
@@ -3964,20 +3328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4043,12 +3393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,16 +3432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro-error-attr3"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4105,18 +3439,6 @@ checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -4151,9 +3473,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -4173,7 +3495,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4192,7 +3514,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4214,25 +3536,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -4249,31 +3558,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4290,15 +3580,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "rand_pcg"
@@ -4336,17 +3617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4397,47 +3667,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 1.11.1",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4451,7 +3680,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4475,7 +3704,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4595,12 +3824,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
@@ -4616,19 +3839,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4636,7 +3846,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -4824,18 +4034,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "tempfile",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.3.0",
 ]
 
 [[package]]
@@ -4855,7 +4056,7 @@ dependencies = [
  "indicatif",
  "log",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "self-replace",
  "semver",
  "serde",
@@ -4918,43 +4119,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_regex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
  "serde",
 ]
 
@@ -5090,12 +4260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5112,16 +4276,6 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -5179,16 +4333,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
+name = "stringmetrics"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
 name = "strsim"
@@ -5201,17 +4349,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -5256,6 +4393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5287,22 +4433,11 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -5369,10 +4504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5451,7 +4583,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5502,38 +4634,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -5546,33 +4657,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5631,6 +4722,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5678,7 +4770,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -5688,12 +4780,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "tz-rs"
-version = "0.6.14"
+name = "typespec"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
- "const_fn",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5738,12 +4872,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -5823,7 +4951,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -5862,12 +4989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2799ffb329a792ecfd902b71306c8a815a6ef1c0470fa9953a6aa4d4cecbe511"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,12 +5016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5918,12 +5033,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -5988,19 +5097,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -6052,14 +5148,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
+ "libc",
 ]
 
 [[package]]
@@ -6163,15 +5256,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6245,15 +5329,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6289,7 +5364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ uuid = { version = "1.26.0", features = ["v7"] }
 tar = "0.4.46"
 flate2 = "1.1.10"
 tempfile = "3.27.0"
-toml = "0.8"
+toml = "1.1"
 age = { version = "0.12.1", default-features = false, features = ["ssh"] }
 age-plugin = "0.7.0"
 age-core = "0.12.0"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -38,7 +38,8 @@ A write failure never changes the command's exit.
 |---|---|
 | Shell wrap, inject, set, approve | `access` after hydrate, `denied` if a disclaimer is withheld, `seen` if nothing matched |
 | Pretool handler, no match | `seen` if the walk says `log` |
-| Pretool handler, match | no (the wrap writes) |
+| Pretool handler, match with nothing to inject | `seen` if those rules say `log`. No ticket. |
+| Pretool handler, match that wraps | no (the wrap writes) |
 | MCP `tools/call` (`lade hook`) | `seen` |
 | `lade mcp` (server start) | same as inject |
 | `lade eval`, `age-plugin-lade` | `access`. Always on. No `lade.yml` `log` flag. |

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/zifeo/lade"
 
 [dependencies]
 access-json = "0.1"
-age = { version = "0.11", features = ["ssh", "plugin", "armor"] }
+age = { version = "0.12", features = ["ssh", "plugin", "armor"] }
 anyhow = "1"
 async-trait = "0.1"
-# secretsmanager's `rustls` feature is hyper 0.14 + rustls 0.21. Keep
+# secretsmanager's `rustls` feature is an older TLS stack. Keep
 # default-https-client (rustls 0.23) only.
 aws-config = { version = "1", default-features = false, features = [
     "behavior-version-latest",
@@ -25,14 +25,14 @@ aws-sdk-secretsmanager = { version = "1", default-features = false, features = [
     "default-https-client",
     "rt-tokio",
 ] }
-# Default enable_reqwest is reqwest 0.12 + native-tls. rustls-only shares 0.23.
-azure_core = { version = "0.21", default-features = false, features = [
-    "enable_reqwest_rustls",
+# Default is reqwest + rustls + tokio. rustls-only shares reqwest 0.13.
+azure_core = { version = "1.1", default-features = false, features = [
+    "reqwest",
+    "reqwest_rustls",
+    "tokio",
 ] }
-azure_identity = { version = "0.21", default-features = false, features = [
-    "development",
-    "enable_reqwest_rustls",
-    "old_azure_cli",
+azure_identity = { version = "1.0", default-features = false, features = [
+    "tokio",
 ] }
 base64 = "0.23"
 directories = "6"
@@ -57,5 +57,5 @@ urlencoding = "2"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "json", "query"] }
 
 [dev-dependencies]
-httpmock = "0.7"
+httpmock = "0.8"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net"] }

--- a/sdk/src/providers/age.rs
+++ b/sdk/src/providers/age.rs
@@ -72,7 +72,7 @@ fn identity_for(uri: &AgeUri, extra_env: &HashMap<String, String>) -> Result<Str
 fn decrypt_blob(identity: &str, blob: &[u8]) -> Result<String> {
     let mut cursor = std::io::Cursor::new(identity.as_bytes());
     let identities = match ::age::ssh::Identity::from_buffer(&mut cursor, None) {
-        Ok(ssh) => vec![Box::new(ssh) as Box<dyn ::age::Identity>],
+        Ok(ssh) => vec![Box::new(ssh) as Box<dyn ::age::Identity + Send + Sync>],
         Err(_) => {
             cursor.set_position(0);
             ::age::IdentityFile::from_buffer(cursor)

--- a/sdk/src/providers/azurekv.rs
+++ b/sdk/src/providers/azurekv.rs
@@ -123,20 +123,64 @@ fn query(url: &Url) -> Option<String> {
         .map(|(_, v)| v.into_owned())
 }
 
+async fn token_from(
+    credential: &dyn azure_core::credentials::TokenCredential,
+    scopes: &[&str],
+) -> Result<String, String> {
+    credential
+        .get_token(scopes, None)
+        .await
+        .map(|token| token.token.secret().to_string())
+        .map_err(|error| error.to_string())
+}
+
 async fn token(extra_env: &HashMap<String, String>, scope: &str) -> Result<String> {
     if let Some(token) = env_lookup(extra_env, &["AZURE_ACCESS_TOKEN", "LADE_AZURE_TOKEN"]) {
         return Ok(token);
     }
-    use azure_core::auth::TokenCredential;
-    let credential = azure_identity::DefaultAzureCredential::create(
-        azure_identity::TokenCredentialOptions::default(),
+    use azure_core::credentials::Secret;
+    let scopes = [scope];
+    let mut errors = Vec::new();
+    if let (Some(tenant), Some(client_id), Some(secret)) = (
+        env_lookup(extra_env, &["AZURE_TENANT_ID"]),
+        env_lookup(extra_env, &["AZURE_CLIENT_ID"]),
+        env_lookup(extra_env, &["AZURE_CLIENT_SECRET"]),
+    ) {
+        match azure_identity::ClientSecretCredential::new(
+            &tenant,
+            client_id,
+            Secret::new(secret),
+            None,
+        ) {
+            Ok(credential) => match token_from(credential.as_ref(), &scopes).await {
+                Ok(token) => return Ok(token),
+                Err(error) => errors.push(error),
+            },
+            Err(error) => errors.push(error.to_string()),
+        }
+    }
+    match azure_identity::DeveloperToolsCredential::new(None) {
+        Ok(credential) => match token_from(credential.as_ref(), &scopes).await {
+            Ok(token) => return Ok(token),
+            Err(error) => errors.push(error),
+        },
+        Err(error) => errors.push(error.to_string()),
+    }
+    match azure_identity::ManagedIdentityCredential::new(None) {
+        Ok(credential) => match token_from(credential.as_ref(), &scopes).await {
+            Ok(token) => return Ok(token),
+            Err(error) => errors.push(error),
+        },
+        Err(error) => errors.push(error.to_string()),
+    }
+    bail!(
+        "Azure Key Vault error: {}. See {DOCS}.",
+        if errors.is_empty() {
+            "no credential succeeded".to_string()
+        } else {
+            errors.join("; ")
+        }
     )
-    .map_err(|e| anyhow!("Azure Key Vault error: {e}. See {DOCS}."))?;
-    let token = credential
-        .get_token(&[scope])
-        .await
-        .map_err(|e| anyhow!("Azure Key Vault error: {e}. See {DOCS}."))?;
-    Ok(token.token.secret().to_string())
 }
 
 #[async_trait]

--- a/sdk/src/providers/vault/tests.rs
+++ b/sdk/src/providers/vault/tests.rs
@@ -73,7 +73,7 @@ async fn test_resolve_multiple_fields_same_key_one_call() {
         .resolve(Path::new("."), &token_env(), &Warnings::default())
         .await
         .unwrap();
-    mock.assert_hits(1);
+    mock.assert_calls(1);
     assert_eq!(
         result
             .get(&format!("vault://{host}/secret/myapp/password"))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,6 +58,14 @@ pub(crate) struct PreEventWork {
     pub progress: SecretSources,
 }
 
+impl PreEventWork {
+    /// Secrets, tunnels, or a disclaimer. `log` / `when` / `silence` alone
+    /// do not need a wrap.
+    pub(crate) fn needs_inject(&self) -> bool {
+        !self.secrets.is_empty() || !self.network.is_empty() || !self.disclaimers.is_empty()
+    }
+}
+
 pub struct Config {
     rules: Vec<(PathBuf, LadeRule)>,
     patterns: Vec<String>,

--- a/src/config/plan.rs
+++ b/src/config/plan.rs
@@ -226,6 +226,17 @@ impl Config {
             .collect()
     }
 
+    /// True when this command needs a process wrap: inject payload or a
+    /// mise pin / bare version for argv0.
+    pub(crate) fn needs_wrap<'a>(
+        work: &super::PreEventWork,
+        command: &str,
+        rules: impl IntoIterator<Item = &'a LadeRule>,
+        saved_user: &Option<String>,
+    ) -> bool {
+        work.needs_inject() || Self::pin_wraps(rules, command, saved_user)
+    }
+
     pub(crate) fn pins(&self, saved_user: &Option<String>) -> Vec<(String, String)> {
         let mut by_key = indexmap::IndexMap::<String, String>::new();
         for (_, rule) in &self.rules {
@@ -244,6 +255,34 @@ impl Config {
             }
         }
         by_key.into_iter().collect()
+    }
+
+    fn pin_wraps<'a>(
+        rules: impl IntoIterator<Item = &'a LadeRule>,
+        command: &str,
+        saved_user: &Option<String>,
+    ) -> bool {
+        let argv0 = crate::mise::argv0(command);
+        let mut has_pin = false;
+        for rule in rules {
+            for (key, secret) in &rule.secrets {
+                match resolve_entry(key, secret, saved_user) {
+                    Some(ResolvedEntry::Pin { key, .. }) => {
+                        has_pin = true;
+                        if key == argv0 {
+                            return true;
+                        }
+                    }
+                    Some(ResolvedEntry::Secret { key, value })
+                        if key == argv0 && crate::mise::looks_like_bare_version(&value) =>
+                    {
+                        return true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        has_pin && crate::mise::is_mise_argv0(argv0)
     }
 
     pub(crate) fn bare_version_for(

--- a/src/config/tests/collect.rs
+++ b/src/config/tests/collect.rs
@@ -277,3 +277,45 @@ fn test_log_on_walk_last_explicit_wins_across_non_matching_rules() {
     let config = LadeFile::build(child).unwrap();
     assert!(!config.log_on_walk());
 }
+
+#[test]
+fn test_log_only_dot_does_not_need_wrap() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("lade.yml"), ".:\n  .:\n    log: true\n").unwrap();
+    let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+    let patterned = config.collect_for_with_pattern("gcloud auth list", Audience::Agent);
+    assert_eq!(patterned.len(), 1);
+    let work = Config::pre_event_work(&patterned, &None).unwrap();
+    assert!(work.log);
+    assert!(!work.needs_inject());
+    assert!(!Config::needs_wrap(
+        &work,
+        "gcloud auth list",
+        patterned.iter().map(|(_, _, rule)| rule),
+        &None,
+    ));
+}
+
+#[test]
+fn test_secret_and_disclaimer_and_pin_need_wrap() {
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("lade.yml"),
+        "\"^echo\":\n  KEY: val\n\"^warn\":\n  .:\n    disclaimer: Danger\n\"^jq\":\n  jq: \"core:jq@1.7.1\"\n",
+    )
+    .unwrap();
+    let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+    for command in ["echo hi", "warn me", "jq --version"] {
+        let patterned = config.collect_for_with_pattern(command, Audience::Agent);
+        let work = Config::pre_event_work(&patterned, &None).unwrap();
+        assert!(
+            Config::needs_wrap(
+                &work,
+                command,
+                patterned.iter().map(|(_, _, rule)| rule),
+                &None,
+            ),
+            "{command}"
+        );
+    }
+}

--- a/src/inject/run.rs
+++ b/src/inject/run.rs
@@ -65,6 +65,25 @@ pub async fn run_inject(
             );
         }
     };
+    if !work.needs_providers() {
+        event::emit_if(
+            work.log,
+            Emit {
+                kind: event::logged_kind(&work.matches),
+                via: ctx.via,
+                audience: ctx.audience,
+                actor: event::actor(&saved_user),
+                cwd: current_dir.to_path_buf(),
+                command: command.clone(),
+                argv: None,
+                hydrated: None,
+                matches: work.matches,
+                hydrate_ms: None,
+                agent: crate::agent_meta::merge(work.agent),
+            },
+        );
+        return run_command_without_providers(&command, &opts, ctx, shell, current_dir, pins.env);
+    }
 
     if let Err(e) = prompt::resolve_disclaimers(ctx, &work.disclaimers, &command).await {
         if e.downcast_ref::<prompt::DisclaimerWithheld>().is_some() {
@@ -162,10 +181,8 @@ pub async fn run_inject(
     }
 }
 
-/// Fast path for a command that matches no rule at all: no disclaimer, no
-/// secret, no network binding can apply, so skip straight to running the
-/// command without spinning up the provider progress thread or any
-/// secret/network machinery.
+/// Fast path when nothing is injected: no disclaimer, no secret, no
+/// network binding. Skip the provider progress thread and hydrate.
 fn run_command_without_providers(
     command: &str,
     opts: &InjectCommand,

--- a/src/inject/set.rs
+++ b/src/inject/set.rs
@@ -55,6 +55,32 @@ pub async fn handle_set(
             return Ok(());
         }
     };
+    if !work.needs_providers() {
+        event::emit_if(
+            work.log,
+            Emit {
+                kind: event::logged_kind(&work.matches),
+                via: ctx.via,
+                audience: ctx.audience,
+                actor: event::actor(&saved_user),
+                cwd: current_dir.clone(),
+                command: command.clone(),
+                argv: None,
+                hydrated: None,
+                matches: work.matches,
+                hydrate_ms: None,
+                agent: crate::agent_meta::merge(work.agent),
+            },
+        );
+        if pins.is_empty() {
+            println!("{}", shell.set(HashMap::new()));
+            return Ok(());
+        }
+        let pre = empty_pre_event(&command, current_dir.clone(), ctx, &saved_user);
+        let id = ticket::write_or_replace(ctx.ticket_id.as_deref(), &pre)?;
+        println!("{}", stamp_preexec(shell, pins.env, &id)?);
+        return Ok(());
+    }
 
     let mut pre = pre_event_from_work(
         &command,

--- a/src/inject/work.rs
+++ b/src/inject/work.rs
@@ -17,6 +17,20 @@ pub(super) struct ProviderWork {
     pub(super) progress: SecretSources,
 }
 
+impl ProviderWork {
+    pub(super) fn needs_inject(&self) -> bool {
+        !self.secrets.is_empty()
+            || !self.network_bindings.is_empty()
+            || !self.disclaimers.is_empty()
+    }
+
+    /// Cancelled keys still need the progress path even when nothing is
+    /// left to inject.
+    pub(super) fn needs_providers(&self) -> bool {
+        self.needs_inject() || !self.progress.cancelled.is_empty()
+    }
+}
+
 pub(super) struct SecretHydrate<'a> {
     pub(super) secrets: &'a [TicketSecret],
     pub(super) op_sa: Option<&'a str>,

--- a/src/mise/mod.rs
+++ b/src/mise/mod.rs
@@ -11,7 +11,7 @@ mod walk;
 mod tests;
 
 pub use error::Error;
-pub use spec::{looks_like_bare_version, looks_like_spec};
+pub use spec::{argv0, is_mise_argv0, looks_like_bare_version, looks_like_spec};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/network/process/tests.rs
+++ b/src/network/process/tests.rs
@@ -8,14 +8,21 @@ use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
+// Parallel unit tests mutate PATH via temp_env (mise stubs, etc.).
+// Command::new("sh") then misses /bin/sh on macOS.
+fn sh_command(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.args(["-c", script]);
+    command
+}
+
 #[test]
 #[cfg(unix)]
 fn child_output_files_creates_missing_tmpdir() {
     let root = tempfile::tempdir().unwrap();
     let gone = root.path().join("gone");
     temp_env::with_var("TMPDIR", Some(gone.to_str().unwrap()), || {
-        let mut command = Command::new("sh");
-        command.args(["-c", "true"]);
+        let mut command = sh_command("true");
         let logs = ChildOutputFiles::capture(&mut command).unwrap();
         logs.cleanup();
     });
@@ -24,8 +31,7 @@ fn child_output_files_creates_missing_tmpdir() {
 #[test]
 #[cfg(unix)]
 fn child_output_files_capture_stdout_and_stderr() {
-    let mut command = Command::new("sh");
-    command.args(["-c", "printf 'out\nout'; printf 'err\nerr' >&2"]);
+    let mut command = sh_command("printf 'out\nout'; printf 'err\nerr' >&2");
     let logs = ChildOutputFiles::capture(&mut command).unwrap();
     let status = command.spawn().unwrap().wait().unwrap();
     assert!(status.success());
@@ -59,11 +65,7 @@ fn dropping_supervisor_terminates_the_provider_process_group() {
         "test forward".to_string(),
         "127.0.0.1".to_string(),
         address.port(),
-        || {
-            let mut command = Command::new("sh");
-            command.args(["-c", "while :; do :; done"]);
-            Ok(command)
-        },
+        || Ok(sh_command("sleep 60")),
     )
     .unwrap();
     drop(forward);
@@ -86,9 +88,7 @@ fn supervisor_retries_a_startup_failure() {
             if attempt == 0 {
                 return Err(anyhow!("simulated startup failure"));
             }
-            let mut command = Command::new("sh");
-            command.args(["-c", "while :; do :; done"]);
-            Ok(command)
+            Ok(sh_command("sleep 60"))
         },
     )
     .unwrap();

--- a/src/pretool/mod.rs
+++ b/src/pretool/mod.rs
@@ -59,25 +59,57 @@ fn pretool_flag() -> &'static str {
 }
 
 /// Bin name for hook install and match rewrites.
-/// `lade install` / `lade hook` stay `lade`. A path in argv[0] uses current_exe.
+/// Bare `lade` stays `lade`. A path in argv[0] uses current_exe unless `lade`
+/// is already on PATH (Cursor often execs the resolved absolute path).
 pub(crate) fn invoked_lade_bin() -> String {
-    invoked_lade_bin_from(env::args_os().next(), env::current_exe().ok())
+    invoked_lade_bin_from(
+        env::args_os().next(),
+        env::current_exe().ok(),
+        lade_on_path(),
+    )
 }
 
 pub(crate) fn invoked_lade_bin_from(
     argv0: Option<OsString>,
     current_exe: Option<PathBuf>,
+    on_path: bool,
 ) -> String {
     let argv0 = argv0.unwrap_or_default();
     let path = Path::new(&argv0);
     if !argv0.is_empty() && path.file_name() == Some(path.as_os_str()) {
         return path.to_str().unwrap_or("lade").to_string();
     }
+    if on_path {
+        if let Some(name) = lade_basename(path) {
+            return name.to_string();
+        }
+        if let Some(name) = current_exe.as_ref().and_then(|p| lade_basename(p)) {
+            return name.to_string();
+        }
+        return "lade".to_string();
+    }
     current_exe
         .and_then(|p| p.to_str().map(str::to_string))
         .or_else(|| argv0.to_str().map(str::to_string))
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "lade".to_string())
+}
+
+fn lade_basename(path: &Path) -> Option<&str> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| matches!(*name, "lade" | "lade.exe"))
+}
+
+pub(crate) fn lade_on_path() -> bool {
+    bin_on_path("lade") || bin_on_path("lade.exe")
+}
+
+fn bin_on_path(name: &str) -> bool {
+    let Some(path) = env::var_os("PATH") else {
+        return false;
+    };
+    env::split_paths(&path).any(|dir| dir.join(name).is_file())
 }
 
 pub fn handle(
@@ -132,26 +164,7 @@ pub fn handle(
 
     let patterned = config.collect_for_with_pattern(&command, audience);
     if patterned.is_empty() {
-        if config.log_on_walk() {
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            let saved_user = GlobalConfig::user_from_disk();
-            event::emit_if(
-                true,
-                Emit {
-                    kind: Kind::Seen,
-                    via: Via::Pretool,
-                    audience,
-                    actor: event::actor(&saved_user),
-                    cwd,
-                    command: command.clone(),
-                    argv: None,
-                    hydrated: None,
-                    matches: json!([]),
-                    hydrate_ms: None,
-                    agent: crate::agent_meta::merge(agent.clone()),
-                },
-            );
-        }
+        emit_seen_pretool(config.log_on_walk(), audience, &command, json!([]), agent);
         return Ok(allow(platform));
     }
 
@@ -160,6 +173,15 @@ pub fn handle(
         Ok(work) => work,
         Err(_) => return Ok(allow(platform)),
     };
+    if !Config::needs_wrap(
+        &work,
+        &command,
+        patterned.iter().map(|(_, _, rule)| rule),
+        &saved_user,
+    ) {
+        emit_seen_pretool(work.log, audience, &command, work.matches, agent);
+        return Ok(allow(platform));
+    }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let pre = PreEvent {
         command: command.clone(),
@@ -250,6 +272,36 @@ fn expects_shell_command(input: &Value) -> bool {
         Some("PreToolUse" | "preToolUse")
     ) || input.get("tool_input").is_some()
         || input.get("hook_source").and_then(Value::as_str) == Some("opencode-plugin")
+}
+
+fn emit_seen_pretool(
+    log: bool,
+    audience: Audience,
+    command: &str,
+    matches: serde_json::Value,
+    agent: serde_json::Value,
+) {
+    if !log {
+        return;
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let saved_user = GlobalConfig::user_from_disk();
+    event::emit_if(
+        true,
+        Emit {
+            kind: Kind::Seen,
+            via: Via::Pretool,
+            audience,
+            actor: event::actor(&saved_user),
+            cwd,
+            command: command.to_string(),
+            argv: None,
+            hydrated: None,
+            matches,
+            hydrate_ms: None,
+            agent: crate::agent_meta::merge(agent),
+        },
+    );
 }
 
 fn warn_unread(reason: &str) {

--- a/src/pretool/tests/wrap.rs
+++ b/src/pretool/tests/wrap.rs
@@ -1,12 +1,14 @@
 use super::super::handle;
 use super::super::invoked_lade_bin_from;
+use super::super::lade_on_path;
 use super::{
     assert_wraps_with_ticket, test_config, test_config_with_disclaimer, with_cursor_env,
     with_ticket_tmpdir,
 };
-use crate::config::Audience;
+use crate::config::{Audience, LadeFile};
 use std::ffi::OsString;
 use std::path::PathBuf;
+use tempfile::tempdir;
 
 #[test]
 fn test_match_wraps_cursor() {
@@ -65,6 +67,63 @@ fn test_match_wraps_codex() {
             });
         },
     );
+}
+
+#[test]
+fn test_log_only_dot_does_not_wrap() {
+    with_cursor_env(|| {
+        with_ticket_tmpdir(|| {
+            let dir = tempdir().unwrap();
+            std::fs::write(dir.path().join("lade.yml"), ".:\n  .:\n    log: true\n").unwrap();
+            let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+            let input = r#"{"tool_input": {"command": "gcloud auth list"}}"#;
+            let result = handle(&config, input, Audience::Agent, None).unwrap();
+            assert!(result.contains("allow"));
+            assert!(!result.contains("updated_input"));
+            assert!(!result.contains("--pretool"));
+            let tickets = std::env::var("LADE_TICKET_DIR").unwrap();
+            assert!(
+                std::fs::read_dir(&tickets).unwrap().next().is_none(),
+                "log-only match must not write a ticket"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_disclaimer_only_is_rewritten() {
+    with_cursor_env(|| {
+        with_ticket_tmpdir(|| {
+            let dir = tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("lade.yml"),
+                "\"^echo\":\n  \".\":\n    disclaimer: \"Danger ahead.\"\n",
+            )
+            .unwrap();
+            let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+            let input = r#"{"tool_input": {"command": "echo hello"}}"#;
+            let result = handle(&config, input, Audience::Agent, None).unwrap();
+            assert_wraps_with_ticket(&result, "echo hello");
+        });
+    });
+}
+
+#[test]
+fn test_pin_only_is_rewritten() {
+    with_cursor_env(|| {
+        with_ticket_tmpdir(|| {
+            let dir = tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("lade.yml"),
+                "\"^jq\":\n  jq: \"core:jq@1.7.1\"\n",
+            )
+            .unwrap();
+            let config = LadeFile::build(dir.path().to_path_buf()).unwrap();
+            let input = r#"{"tool_input": {"command": "jq --version"}}"#;
+            let result = handle(&config, input, Audience::Agent, None).unwrap();
+            assert_wraps_with_ticket(&result, "jq --version");
+        });
+    });
 }
 
 #[test]
@@ -237,19 +296,56 @@ fn unread_pretool_without_command_allows_and_stays_open() {
 fn invoked_lade_bin_from_path_stays_bare() {
     let exe = PathBuf::from("/opt/lade");
     assert_eq!(
-        invoked_lade_bin_from(Some(OsString::from("lade")), Some(exe.clone())),
+        invoked_lade_bin_from(Some(OsString::from("lade")), Some(exe.clone()), false),
         "lade"
     );
     assert_eq!(
-        invoked_lade_bin_from(Some(OsString::from("lade.exe")), Some(exe.clone())),
+        invoked_lade_bin_from(Some(OsString::from("lade.exe")), Some(exe.clone()), false),
         "lade.exe"
     );
     assert_eq!(
-        invoked_lade_bin_from(Some(OsString::from("/opt/custom/lade")), Some(exe.clone())),
+        invoked_lade_bin_from(
+            Some(OsString::from("/opt/custom/lade")),
+            Some(exe.clone()),
+            false
+        ),
         "/opt/lade"
     );
     assert_eq!(
-        invoked_lade_bin_from(Some(OsString::from("./target/debug/lade")), Some(exe)),
+        invoked_lade_bin_from(
+            Some(OsString::from("./target/debug/lade")),
+            Some(exe),
+            false
+        ),
         "/opt/lade"
     );
+}
+
+#[test]
+fn invoked_lade_bin_from_path_falls_back_when_on_path() {
+    let exe = PathBuf::from("/Users/me/.cargo/bin/lade");
+    assert_eq!(
+        invoked_lade_bin_from(
+            Some(OsString::from("/Users/me/.cargo/bin/lade")),
+            Some(exe.clone()),
+            true
+        ),
+        "lade"
+    );
+    assert_eq!(
+        invoked_lade_bin_from(Some(OsString::from("./target/debug/lade")), Some(exe), true),
+        "lade"
+    );
+}
+
+#[test]
+fn lade_on_path_sees_a_file() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("lade"), b"").unwrap();
+    temp_env::with_var("PATH", Some(dir.path()), || {
+        assert!(lade_on_path());
+    });
+    temp_env::with_var("PATH", Some("/no/such/lade-path"), || {
+        assert!(!lade_on_path());
+    });
 }

--- a/tests/binary_weight.rs
+++ b/tests/binary_weight.rs
@@ -40,7 +40,7 @@ fn runtime_graph_stays_on_one_rustls_stack() {
         .collect();
     assert!(
         extra.is_empty(),
-        "forbidden runtime TLS/OpenSSL crates: {extra:?}. rustls-native-certs may pull openssl-probe on Linux to find the CA bundle. That is not a second TLS stack. Azure must keep enable_reqwest_rustls only. AWS must not enable the secretsmanager `rustls` feature (legacy 0.21 stack)."
+        "forbidden runtime TLS/OpenSSL crates: {extra:?}. rustls-native-certs may pull openssl-probe on Linux to find the CA bundle. That is not a second TLS stack. Azure must keep reqwest_rustls only. AWS must not enable the secretsmanager `rustls` feature (legacy stack)."
     );
 
     let rustls = pkgs.get("rustls").map(Vec::as_slice).unwrap_or(&[]);

--- a/tests/log_emit/write.rs
+++ b/tests/log_emit/write.rs
@@ -155,6 +155,79 @@ fn hook_no_match_writes_nothing() {
 }
 
 #[test]
+fn hook_log_only_match_writes_seen_without_ticket() {
+    let home = tempdir().unwrap();
+    let dir = tempdir().unwrap();
+    let tickets = tempdir().unwrap();
+    write_yml_raw(dir.path(), ".:\n  .:\n    log: true\n");
+    let out = common::lade(home.path())
+        .current_dir(dir.path())
+        .env("CURSOR_VERSION", "1.0")
+        .env("LADE_TICKET_DIR", tickets.path())
+        .args(["hook"])
+        .write_stdin(
+            r#"{"tool_name":"Shell","tool_input":{"command":"gcloud auth list"},"hook_event_name":"preToolUse","conversation_id":"conv_log"}"#,
+        )
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&out);
+    assert!(!stdout.contains("--pretool"), "{stdout}");
+    assert!(
+        tickets.path().read_dir().unwrap().next().is_none(),
+        "hook must not write a ticket when nothing is injected"
+    );
+    let rows = log_rows(home.path(), dir.path());
+    assert_eq!(rows.as_array().unwrap().len(), 1);
+    assert_eq!(rows[0]["kind"], "seen");
+    assert_eq!(rows[0]["via"], "pretool");
+    assert_eq!(row_line(&rows[0]), "gcloud auth list");
+    assert_eq!(rows[0]["agent"]["harness"], "cursor");
+    assert_eq!(rows[0]["agent"]["session"], "conv_log");
+}
+
+#[test]
+fn hook_log_only_uses_matched_log_not_walk() {
+    let home = tempdir().unwrap();
+    let dir = tempdir().unwrap();
+    write_yml_raw(
+        dir.path(),
+        ".:\n  .:\n    log: true\n\"^git status\":\n  .:\n    log: false\n",
+    );
+    let hook = |command: &str| {
+        common::lade(home.path())
+            .current_dir(dir.path())
+            .env("CURSOR_VERSION", "1.0")
+            .args(["hook"])
+            .write_stdin(format!(
+                r#"{{"tool_name":"Shell","tool_input":{{"command":"{command}"}},"hook_event_name":"preToolUse"}}"#
+            ))
+            .assert()
+            .success();
+    };
+    hook("echo hi");
+    hook("git status");
+    let rows = log_rows(home.path(), dir.path());
+    let cmds: Vec<String> = rows.as_array().unwrap().iter().map(row_line).collect();
+    assert!(cmds.iter().any(|c| c == "echo hi"), "{cmds:?}");
+    assert!(!cmds.iter().any(|c| c.contains("git status")), "{cmds:?}");
+    assert!(
+        rows.as_array()
+            .unwrap()
+            .iter()
+            .all(|row| row["kind"] == "seen")
+    );
+    assert!(
+        rows.as_array()
+            .unwrap()
+            .iter()
+            .all(|row| row["via"] == "pretool")
+    );
+}
+
+#[test]
 fn hook_no_match_walk_log_writes_seen() {
     let home = tempdir().unwrap();
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Skip the process wrap and ticket when a matched rule only logs. Secrets, tunnels, disclaimers, and mise pins still wrap.
- Emit `seen` from pretool and inject on that path. Rewrite hook argv as bare `lade` when it is already on PATH.
- Bump Azure Identity and age so the SDK stays on one rustls stack.

## Test plan
- [ ] `lade hook` with `.: { log: true }` allows without `--pretool` or a ticket, and writes a `seen` row when logging is on
- [ ] A match with a secret, disclaimer, or `core:jq@…` pin still rewrites the command
- [ ] Azure Key Vault hydrate still works with client secret, developer tools, and managed identity
